### PR TITLE
lattice.py split into files

### DIFF
--- a/qutip_lattice/__init__.py
+++ b/qutip_lattice/__init__.py
@@ -1,3 +1,6 @@
 # lattice models
-from .lattice import *
+from .lattice_operators import *
+from .lattice_sp import *
 from .topology import *
+from .fermions_mp import *
+from .bosons_mp import *

--- a/qutip_lattice/bosons_mp.py
+++ b/qutip_lattice/bosons_mp.py
@@ -1,0 +1,1756 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, The QuTiP Project.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+from scipy.sparse import (csr_matrix)
+import scipy.io as spio
+from qutip import (Qobj, tensor, basis, qeye, isherm, sigmax, sigmay, sigmaz,
+                   create, destroy)
+
+import numpy as np
+
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    pass
+
+
+from scipy import sparse
+from scipy.sparse.linalg import eigs
+import operator as op
+from functools import reduce
+import copy
+from numpy import asarray
+import math
+from .tran_sym_functions import *
+from .lattice_operators import *
+from .spinless_functions import *
+
+__all__ = ['Lattice1d_bose_Hubbard', 'Lattice1d_hardcorebosons',
+           'Lattice1d_2c_hcb_Hubbard']
+
+class Lattice1d_hardcorebosons():
+    """A class for representing a 1d lattice with fermions hopping around in
+    the many particle physics picture.
+
+    The Lattice1d_fermions class can be defined with any specific unit cells
+    and a specified number of unit cells in the crystal.  It can return
+    Hamiltonians written in a chosen (with specific symmetry) basis and
+    unitary transformations that can be used in switching between them.
+
+    Parameters
+    ----------
+    num_sites : int
+        The number of sites in the fermi Hubbard lattice.
+    PP : int
+        The exchange phase factor for particles, -1 for fermions
+    boundary : str
+        Specification of the type of boundary the crystal is defined with.
+    t : float
+        The nearest neighbor hopping integral.
+
+    Attributes
+    ----------
+    num_sites : int
+        The number of sites in the fermi Hubbard lattice.
+    latticeType : str
+        A cubic lattice geometry isa ssumed.
+    period_bnd_cond_x : int
+        1 indicates "periodic" and 0 indicates "hardwall" boundary condition
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    """
+    def __init__(self, num_sites=10, boundary="periodic", t=1):
+        self.latticeType = 'cubic'
+        self.paramT = t
+        self.latticeSize = [num_sites]
+        self.PP = 1
+
+        if (not isinstance(num_sites, int)) or num_sites > 30:
+            raise Exception("cell_num_site is required to be a positive \
+                            integer.")
+
+        if boundary == "periodic":
+            self.period_bnd_cond_x = 1
+        elif boundary == "aperiodic" or boundary == "hardwall":
+            self.period_bnd_cond_x = 0
+        else:
+            raise Exception("Error in boundary: Only recognized bounday \
+                    options are:\"periodic \",\"aperiodic\" and \"hardwall\" ")
+
+    def __repr__(self):
+        s = ""
+        s += ("Lattice1d_f_HubbardN object: " +
+              "Number of sites = " + str(self.num_sites) +
+              ",\n hopping energy between sites, t = " + str(self.paramT) +
+              ",\n number of spin up fermions = " +
+              str(self.fillingUp) +
+              ",\n number of spin down fermions = " + str(self.fillingDown) +
+              ",\n k - vector sector = " + str(self.k) + "\n")
+        if self.period_bnd_cond_x == 1:
+            s += "Boundary Condition:  Periodic"
+        else:
+            s += "Boundary Condition:  Hardwall"
+        return s
+
+    def Hamiltonian(self, filling=None, kval=None):
+        """
+        Returns the Hamiltonian for the instance of Lattice1d_hardcorebosons.
+
+        filling : int
+            The number of excitations in each basis member.
+        kval : int
+            The index of reciprocal lattice vector specified for each basis
+            member.
+
+        Returns
+        ----------
+        Hamiltonian : qutip.Qobj
+            oper type Quantum object representing the lattice Hamiltonian.
+        basis : qutip.Oobj
+            The basis that the Hamiltonian is formed in.
+        """
+        if filling is None and kval is None:
+            Hamiltonian_list = spinlessFermions_NoSymHamiltonian(
+                self.paramT, self.latticeType, self.latticeSize, self.PP,
+                self.period_bnd_cond_x)
+        elif filling is not None and kval is None:
+            Hamiltonian_list = spinlessFermions_Only_nums(
+                self.paramT, self.latticeType, self.latticeSize, filling,
+                self.PP, self.period_bnd_cond_x)
+        elif filling is not None and kval is not None:
+            Hamiltonian_list = spinlessFermions_nums_Trans(
+                self.paramT, self.latticeType, self.latticeSize, filling, kval,
+                self.PP, self.period_bnd_cond_x)
+        elif filling is None and kval is not None:
+            Hamiltonian_list = spinlessFermions_OnlyTrans(
+                self.paramT, self.latticeType, self.latticeSize, kval, self.PP,
+                self.period_bnd_cond_x)
+
+        return Hamiltonian_list
+
+    def NoSym_DiagTrans(self):
+        """
+        Computes the unitary matrix that block-diagonalizes the Hamiltonian
+        written in a basis with k-vector symmetry.
+
+        Returns
+        -------
+        Qobj(Usss) : Qobj(csr_matrix)
+            The unitary matrix that block-diagonalizes the Hamiltonian written
+            in a basis with k-vector symmetry.
+        """
+        latticeSize = self.latticeSize
+        PP = 1
+        nSites = latticeSize[0]
+        kVector = np.arange(start=0, stop=2*np.pi, step=2*np.pi/nSites)
+        symOpInvariantsUp = np.array([np.power(1, np.arange(nSites))])
+        basisStates_S = createHeisenbergfullBasis(latticeSize[0])
+        [nBasisStates, dumpV] = np.shape(basisStates_S)
+        bin2dez = np.arange(nSites-1, -1, -1)
+        bin2dez = np.power(2, bin2dez)
+        intDownStates = np.sum(basisStates_S * bin2dez, axis=1)
+
+        Is = 0
+        RowIndexUs = 0
+        sumL = 0
+        cumulIndex = np.zeros(nSites+1, dtype=int)
+        cumulIndex[0] = 0
+        # loop over k-vector
+        for ikVector in range(nSites):
+            kValue = kVector[ikVector]
+
+            [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+             ] = combine2HubbardBasisOnlyTrans(
+             symOpInvariantsUp, basisStates_S, latticeSize, kValue, PP, Nmax=1)
+            sumL = sumL + np.size(Ind2kDown[0])
+            cumulIndex[ikVector+1] = sumL
+            DownStatesPerk = DownStatesPerk[0]
+            [nReprUp, dumpV] = np.shape(DownStatesPerk)
+
+            for k in range(nReprUp):
+                DownState = DownStatesPerk[k, :]
+                DownState_int = np.sum(DownState * bin2dez, axis=0)
+
+                if DownState_int == intDownStates[0]:
+                    NewRI = k + RowIndexUs
+                    NewCI = 0
+                    NewEn = 1
+
+                    if Is == 0:
+                        UssRowIs = np.array([NewRI])
+                        UssColIs = np.array([NewCI])
+                        UssEntries = np.array([NewEn])
+                        Is = 1
+                    elif Is > 0:
+                        DLT = np.argwhere(UssRowIs == NewRI)
+                        iArg1 = DLT[:, 0]
+                        DLT = np.argwhere(UssColIs == NewCI)
+                        iArg2 = DLT[:, 0]
+                        if np.size(np.intersect1d(iArg1, iArg2)):
+                            AtR = np.intersect1d(iArg1, iArg2)
+                            UssEntries[AtR] = UssEntries[AtR] + NewEn
+                        else:
+                            Is = Is + 1
+                            UssRowIs = np.append(UssRowIs, np.array([NewRI]),
+                                                 axis=0)
+                            UssColIs = np.append(UssColIs, np.array([NewCI]),
+                                                 axis=0)
+                            UssEntries = np.append(UssEntries, np.array(
+                                [NewEn]), axis=0)
+
+                elif DownState_int == intDownStates[-1]:
+                    NewRI = k + RowIndexUs
+                    NewCI = np.power(2, nSites) - 1
+                    NewEn = 1
+
+                    if Is == 0:
+                        UssRowIs = np.array([NewRI])
+                        UssColIs = np.array([NewCI])
+                        UssEntries = np.array([NewEn])
+                        Is = 1
+                    elif Is > 0:
+                        DLT = np.argwhere(UssRowIs == NewRI)
+                        iArg1 = DLT[:, 0]
+                        DLT = np.argwhere(UssColIs == NewCI)
+                        iArg2 = DLT[:, 0]
+                        if np.size(np.intersect1d(iArg1, iArg2)):
+                            AtR = np.intersect1d(iArg1, iArg2)
+                            UssEntries[AtR] = UssEntries[AtR] + NewEn
+                        else:
+                            Is = Is + 1
+                            UssRowIs = np.append(UssRowIs, np.array([NewRI]),
+                                                 axis=0)
+                            UssColIs = np.append(UssColIs, np.array([NewCI]),
+                                                 axis=0)
+                            UssEntries = np.append(UssEntries, np.array(
+                                [NewEn]), axis=0)
+
+                else:
+                    # calculate period
+                    for h in range(1, nSites+1, 1):
+                        DownState_S = np.roll(DownState, -h)
+                        if (DownState_S == DownState).all():
+                            pn = h
+                            break
+
+                    no_of_flips = 0
+                    DownState_shifted = DownState
+                    for m in range(nSites):
+                        DownState_m = np.roll(DownState, -m)
+                        DownState_m_int = np.sum(DownState_m * bin2dez, axis=0)
+                        DLT = np.argwhere(intDownStates == DownState_m_int)
+                        ind_down = DLT[:, 0][0]
+
+                        if m > 0:
+                            DownState_shifted = np.roll(DownState_shifted, -1)
+                            if np.mod(np.count_nonzero(DownState) + 1, 2):
+                                no_of_flips = no_of_flips
+                                + DownState_shifted[-1]
+
+                        else:
+                            no_of_flips = 0
+
+                        NewRI = k + RowIndexUs
+                        NewCI = ind_down
+                        NewEn = np.sqrt(pn)/nSites * np.power(
+                            PP, no_of_flips) * np.exp(
+                                -2 * np.pi * 1J / nSites * ikVector * m)
+
+                        if Is == 0:
+                            UssRowIs = np.array([NewRI])
+                            UssColIs = np.array([NewCI])
+                            UssEntries = np.array([NewEn])
+                            Is = 1
+                        elif Is > 0:
+                            DLT = np.argwhere(UssRowIs == NewRI)
+                            iArg1 = DLT[:, 0]
+                            DLT = np.argwhere(UssColIs == NewCI)
+                            iArg2 = DLT[:, 0]
+                            if np.size(np.intersect1d(iArg1, iArg2)):
+                                AtR = np.intersect1d(iArg1, iArg2)
+                                UssEntries[AtR] = UssEntries[AtR] + NewEn
+                            else:
+                                Is = Is + 1
+                                UssRowIs = np.append(
+                                    UssRowIs, np.array([NewRI]), axis=0)
+                                UssColIs = np.append(
+                                    UssColIs, np.array([NewCI]), axis=0)
+                                UssEntries = np.append(
+                                    UssEntries, np.array([NewEn]), axis=0)
+
+            RowIndexUs = RowIndexUs + cumulIndex[
+                ikVector+1] - cumulIndex[ikVector]
+        Usss = sparse.csr_matrix((UssEntries, (UssRowIs, UssColIs)),
+                                 shape=(nBasisStates, nBasisStates))
+        return Qobj(Usss)
+
+    def NoSym_DiagTrans_k(self, kval):
+        """
+        Computes the section of the unitary matrix that computes the
+        block-diagonalized Hamiltonian written in a basis with the given
+        k-vector symmetry.
+
+        Parameters
+        ==========
+        kval : int
+            The index of wave-vector which the basis members would have the
+            symmetry of.
+
+        Returns
+        -------
+        Qobj(Usss) : Qobj(csr_matrix)
+            The section of the unitary matrix that gives the Hamiltonian
+            written in a basis with k-vector symmetry.
+        """
+        latticeSize = self.latticeSize
+        PP = 1
+        nSites = latticeSize[0]
+        kVector = np.arange(start=0, stop=2 * np.pi, step=2 * np.pi / nSites)
+        symOpInvariantsUp = np.array([np.power(1, np.arange(nSites))])
+
+        basisStates_S = createHeisenbergfullBasis(latticeSize[0])
+        [nBasisStates, dumpV] = np.shape(basisStates_S)
+        bin2dez = np.arange(nSites - 1, -1, -1)
+        bin2dez = np.power(2, bin2dez)
+        intDownStates = np.sum(basisStates_S * bin2dez, axis=1)
+
+        Is = 0
+        RowIndexUs = 0
+        sumL = 0
+        cumulIndex = np.zeros(nSites + 1, dtype=int)
+        cumulIndex[0] = 0
+        # loop over k-vector
+        for ikVector in range(kval, kval + 1, 1):
+            kValue = kVector[ikVector]
+
+            [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+             ] = combine2HubbardBasisOnlyTrans(
+                 symOpInvariantsUp, basisStates_S, latticeSize, kValue, PP,
+                 Nmax=1)
+            sumL = sumL + np.size(Ind2kDown[0])
+            cumulIndex[ikVector+1] = sumL
+            DownStatesPerk = DownStatesPerk[0]
+            [nReprUp, dumpV] = np.shape(DownStatesPerk)
+
+            for k in range(nReprUp):
+                DownState = DownStatesPerk[k, :]
+                DownState_int = np.sum(DownState * bin2dez, axis=0)
+                if DownState_int == intDownStates[0]:
+                    NewRI = k + RowIndexUs
+                    NewCI = 0
+                    NewEn = 1
+                    if Is == 0:
+                        UssRowIs = np.array([NewRI])
+                        UssColIs = np.array([NewCI])
+                        UssEntries = np.array([NewEn])
+                        Is = 1
+                    elif Is > 0:
+                        DLT = np.argwhere(UssRowIs == NewRI)
+                        iArg1 = DLT[:, 0]
+                        DLT = np.argwhere(UssColIs == NewCI)
+                        iArg2 = DLT[:, 0]
+                        if np.size(np.intersect1d(iArg1, iArg2)):
+                            AtR = np.intersect1d(iArg1, iArg2)
+                            UssEntries[AtR] = UssEntries[AtR] + NewEn
+                        else:
+                            Is = Is + 1
+                            UssRowIs = np.append(UssRowIs, np.array([NewRI]),
+                                                 axis=0)
+                            UssColIs = np.append(
+                                UssColIs, np.array([NewCI]), axis=0)
+                            UssEntries = np.append(UssEntries, np.array(
+                                [NewEn]), axis=0)
+
+                elif DownState_int == intDownStates[-1]:
+                    NewRI = k + RowIndexUs
+                    NewCI = np.power(2, nSites) - 1
+                    NewEn = 1
+
+                    if Is == 0:
+                        UssRowIs = np.array([NewRI])
+                        UssColIs = np.array([NewCI])
+                        UssEntries = np.array([NewEn])
+                        Is = 1
+                    elif Is > 0:
+                        DLT = np.argwhere(UssRowIs == NewRI)
+                        iArg1 = DLT[:, 0]
+                        DLT = np.argwhere(UssColIs == NewCI)
+                        iArg2 = DLT[:, 0]
+                        if np.size(np.intersect1d(iArg1, iArg2)):
+                            AtR = np.intersect1d(iArg1, iArg2)
+                            UssEntries[AtR] = UssEntries[AtR] + NewEn
+                        else:
+                            Is = Is + 1
+                            UssRowIs = np.append(UssRowIs, np.array([NewRI]),
+                                                 axis=0)
+                            UssColIs = np.append(UssColIs, np.array([NewCI]),
+                                                 axis=0)
+                            UssEntries = np.append(UssEntries, np.array(
+                                [NewEn]), axis=0)
+
+                else:
+                    # calculate period
+                    for h in range(1, nSites+1, 1):
+                        DownState_S = np.roll(DownState, -h)
+
+                        if (DownState_S == DownState).all():
+                            pn = h
+                            break
+
+                    no_of_flips = 0
+                    DownState_shifted = DownState
+
+                    for m in range(nSites):
+                        DownState_m = np.roll(DownState, -m)
+                        DownState_m_int = np.sum(DownState_m * bin2dez, axis=0)
+
+                        DLT = np.argwhere(intDownStates == DownState_m_int)
+                        ind_down = DLT[:, 0][0]
+
+                        if m > 0:
+                            DownState_shifted = np.roll(DownState_shifted, -1)
+
+                            if np.mod(np.count_nonzero(DownState) + 1, 2):
+                                no_of_flips = no_of_flips + DownState_shifted[
+                                    -1]
+                        else:
+                            no_of_flips = 0
+
+                        NewRI = k + RowIndexUs
+                        NewCI = ind_down
+                        NewEn = np.sqrt(
+                            pn) / nSites * np.power(PP, no_of_flips) * np.exp(
+                                -2 * np.pi * 1J / nSites * ikVector * m)
+
+                        if Is == 0:
+                            UssRowIs = np.array([NewRI])
+                            UssColIs = np.array([NewCI])
+                            UssEntries = np.array([NewEn])
+                            Is = 1
+                        elif Is > 0:
+                            DLT = np.argwhere(UssRowIs == NewRI)
+                            iArg1 = DLT[:, 0]
+                            DLT = np.argwhere(UssColIs == NewCI)
+                            iArg2 = DLT[:, 0]
+                            if np.size(np.intersect1d(iArg1, iArg2)):
+                                AtR = np.intersect1d(iArg1, iArg2)
+                                UssEntries[AtR] = UssEntries[AtR] + NewEn
+                            else:
+                                Is = Is + 1
+                                UssRowIs = np.append(
+                                    UssRowIs, np.array([NewRI]), axis=0)
+                                UssColIs = np.append(
+                                    UssColIs, np.array([NewCI]), axis=0)
+                                UssEntries = np.append(
+                                    UssEntries, np.array([NewEn]), axis=0)
+
+            RowIndexUs = RowIndexUs + cumulIndex[ikVector+1] - cumulIndex[
+                ikVector]
+
+        Usss = sparse.csr_matrix((UssEntries, (UssRowIs, UssColIs)),
+                                 shape=(sumL, np.power(2, nSites)))
+        return Qobj(Usss)
+
+    def nums_DiagTrans(self, filling):
+        """
+        Computes the unitary matrix that block-diagonalizes the Hamiltonian
+        written in a basis without k-vector symmetry to with it.
+
+        Parameters
+        ==========
+        filling : int
+            The number of excitations in each basis member.
+
+        Returns
+        -------
+        Qobj(Usss) : Qobj(csr_matrix)
+            The unitary matrix that block-diagonalizes the Hamiltonian written
+            in a basis with k-vector symmetry.
+        """
+        latticeSize = self.latticeSize
+        PP = self.PP
+        nSites = latticeSize[0]
+        kVector = np.arange(start=0, stop=2 * np.pi, step=2 * np.pi / nSites)
+
+        symOpInvariantsUp = np.array([np.power(1, np.arange(nSites))])
+        nStatesDown = ncr(nSites, filling)
+        [basisStates_S, integerBasisDown, indOnesDown
+         ] = createHeisenbergBasis(nStatesDown, nSites, filling)
+
+        [nBasisStates, dumpV] = np.shape(basisStates_S)
+        bin2dez = np.arange(nSites-1, -1, -1)
+        bin2dez = np.power(2, bin2dez)
+        intDownStates = np.sum(basisStates_S * bin2dez, axis=1)
+
+        Is = 0
+        RowIndexUs = 0
+        sumL = 0
+        cumulIndex = np.zeros(nSites+1, dtype=int)
+        cumulIndex[0] = 0
+        # loop over k-vector
+        for ikVector in range(nSites):
+            kValue = kVector[ikVector]
+            [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+             ] = combine2HubbardBasisOnlyTrans(
+             symOpInvariantsUp, basisStates_S, latticeSize, kValue, PP, Nmax=1)
+            sumL = sumL + np.size(Ind2kDown[0])
+            cumulIndex[ikVector+1] = sumL
+            DownStatesPerk = DownStatesPerk[0]
+            [nReprUp, dumpV] = np.shape(DownStatesPerk)
+
+            for k in range(nReprUp):
+                DownState = DownStatesPerk[k, :]
+
+                # calculate period
+                for h in range(1, nSites + 1, 1):
+                    DownState_S = np.roll(DownState, -h)
+                    if (DownState_S == DownState).all():
+                        pn = h
+                        break
+                no_of_flips = 0
+                DownState_shifted = DownState
+
+                for m in range(nSites):
+                    DownState_m = np.roll(DownState, -m)
+                    DownState_m_int = np.sum(DownState_m * bin2dez, axis=0)
+
+                    DLT = np.argwhere(intDownStates == DownState_m_int)
+                    ind_down = DLT[:, 0][0]
+
+                    if m > 0:
+                        DownState_shifted = np.roll(DownState_shifted, -1)
+                        if np.mod(np.count_nonzero(DownState) + 1, 2):
+                            no_of_flips = no_of_flips + DownState_shifted[-1]
+
+                    else:
+                        no_of_flips = 0
+
+                    NewRI = k + RowIndexUs
+                    NewCI = ind_down
+                    NewEn = np.sqrt(pn) / nSites * np.power(
+                        PP, no_of_flips) * np.exp(-2 * np.pi * 1J / nSites * (
+                            ikVector) * m)
+
+                    if Is == 0:
+                        UssRowIs = np.array([NewRI])
+                        UssColIs = np.array([NewCI])
+                        UssEntries = np.array([NewEn])
+                        Is = 1
+                    elif Is > 0:
+                        DLT = np.argwhere(UssRowIs == NewRI)
+                        iArg1 = DLT[:, 0]
+                        DLT = np.argwhere(UssColIs == NewCI)
+                        iArg2 = DLT[:, 0]
+                        if np.size(np.intersect1d(iArg1, iArg2)):
+                            AtR = np.intersect1d(iArg1, iArg2)
+                            UssEntries[AtR] = UssEntries[AtR] + NewEn
+                        else:
+                            Is = Is + 1
+                            UssRowIs = np.append(UssRowIs,
+                                                 np.array([NewRI]), axis=0)
+                            UssColIs = np.append(UssColIs,
+                                                 np.array([NewCI]), axis=0)
+                            UssEntries = np.append(UssEntries,
+                                                   np.array([NewEn]), axis=0)
+
+            RowIndexUs = RowIndexUs + cumulIndex[
+                ikVector+1] - cumulIndex[ikVector]
+
+        Usss = sparse.csr_matrix((UssEntries, (UssRowIs, UssColIs)),
+                                 shape=(nBasisStates, nBasisStates))
+
+        return Qobj(Usss)
+
+    def nums_DiagTrans_k(self, filling, kval):
+        """
+        Computes the section of the unitary matrix that computes the
+        block-diagonalized Hamiltonian written in a basis with the given
+        k-vector and number symmetry.
+
+        Parameters
+        ==========
+        filling : int
+            The specified number of excitations in each basis member.
+        kval : int
+            The index of wave-vector which the basis members would have the
+            symmetry of.
+
+        Returns
+        -------
+        Qobj(Usss) : Qobj(csr_matrix)
+            The section of the unitary matrix that gives the Hamiltonian
+            written in a basis with k-vector symmetry.
+        """
+        latticeSize = self.latticeSize
+        PP = self.PP
+        nSites = latticeSize[0]
+        kVector = np.arange(start=0, stop=2 * np.pi, step=2 * np.pi / nSites)
+
+        symOpInvariantsUp = np.array([np.power(1, np.arange(nSites))])
+        nStatesDown = ncr(nSites, filling)
+        [basisStates_S, integerBasisDown, indOnesDown
+         ] = createHeisenbergBasis(nStatesDown, nSites, filling)
+
+        [nBasisStates, dumpV] = np.shape(basisStates_S)
+        bin2dez = np.arange(nSites-1, -1, -1)
+        bin2dez = np.power(2, bin2dez)
+        intDownStates = np.sum(basisStates_S*bin2dez, axis=1)
+
+        Is = 0
+        sumL = 0
+        cumulIndex = np.zeros(nSites+1, dtype=int)
+        cumulIndex[0] = 0
+
+        for ikVector in range(latticeSize[0]):
+            kValue = kVector[kval]
+            [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+             ] = combine2HubbardBasisOnlyTrans(
+             symOpInvariantsUp, basisStates_S, latticeSize, kValue, PP, Nmax=1)
+            sumL = sumL + np.size(Ind2kDown[0])
+            cumulIndex[ikVector+1] = sumL
+
+        kValue = kVector[kval]
+        [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+         ] = combine2HubbardBasisOnlyTrans(
+         symOpInvariantsUp, basisStates_S, latticeSize, kValue, PP, Nmax=1)
+        DownStatesPerk = DownStatesPerk[0]
+        [nReprUp, dumpV] = np.shape(DownStatesPerk)
+
+        for k in range(nReprUp):
+            DownState = DownStatesPerk[k, :]
+
+            # calculate period
+            for h in range(1, nSites+1, 1):
+                DownState_S = np.roll(DownState, -h)
+
+                if (DownState_S == DownState).all():
+                    pn = h
+                    break
+
+            no_of_flips = 0
+            DownState_shifted = DownState
+            for m in range(nSites):
+                DownState_m = np.roll(DownState, -m)
+                DownState_m_int = np.sum(DownState_m * bin2dez, axis=0)
+                DLT = np.argwhere(intDownStates == DownState_m_int)
+                ind_down = DLT[:, 0][0]
+                if m > 0:
+                    DownState_shifted = np.roll(DownState_shifted, -1)
+                    if np.mod(np.count_nonzero(DownState) + 1, 2):
+                        no_of_flips = no_of_flips + DownState_shifted[-1]
+                else:
+                    no_of_flips = 0
+
+                NewRI = k
+                NewCI = ind_down
+                NewEn = np.sqrt(pn) / nSites * np.power(
+                    PP, no_of_flips) * np.exp(
+                        -2 * np.pi * 1J / nSites * kval * m)
+
+                if Is == 0:
+                    UssRowIs = np.array([NewRI])
+                    UssColIs = np.array([NewCI])
+                    UssEntries = np.array([NewEn])
+                    Is = 1
+                elif Is > 0:
+                    DLT = np.argwhere(UssRowIs == NewRI)
+                    iArg1 = DLT[:, 0]
+                    DLT = np.argwhere(UssColIs == NewCI)
+                    iArg2 = DLT[:, 0]
+                    if np.size(np.intersect1d(iArg1, iArg2)):
+                        AtR = np.intersect1d(iArg1, iArg2)
+                        UssEntries[AtR] = UssEntries[AtR] + NewEn
+                    else:
+                        Is = Is + 1
+                        UssRowIs = np.append(UssRowIs, np.array([NewRI]),
+                                             axis=0)
+                        UssColIs = np.append(UssColIs, np.array([NewCI]),
+                                             axis=0)
+                        UssEntries = np.append(UssEntries, np.array([NewEn]),
+                                               axis=0)
+
+        Usss = sparse.csr_matrix((UssEntries, (UssRowIs, UssColIs)),
+                                 shape=(cumulIndex[kval+1]-cumulIndex[kval],
+                                        nBasisStates))
+
+        return Qobj(Usss)
+
+
+class Lattice1d_bose_Hubbard():
+    """A class for representing a 1d bose Hubbard model.
+
+    The Lattice1d_bose_Hubbard class is defined with a specific unit cells
+    and parameters of the bose Hubbard model. It can return
+    Hamiltonians written in a chosen (with specific symmetry) basis and unitary
+    transformations that can be used in switching between them.
+
+    Parameters
+    ----------
+    num_sites : int
+        The number of sites in the fermi Hubbard lattice.
+    PP : int
+        The exchange phase factor for particles, 1 for bosons
+    boundary : str
+        Specification of the type of boundary the crystal is defined with.
+    t : float
+        The nearest neighbor hopping integral.
+    U : float
+        The onsite interaction strngth of the Hubbard model.
+
+    Attributes
+    ----------
+    num_sites : int
+        The number of sites in the fermi Hubbard lattice.
+    period_bnd_cond_x : int
+        1 indicates "periodic" and 0 indicates "hardwall" boundary condition
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    """
+    def __init__(self, num_sites=10, boundary="periodic", t=1, U=1):
+        self.latticeType = 'cubic'
+        self.paramT = t
+        self.paramU = U
+        self.latticeSize = [num_sites]
+        self.PP = 1
+
+        if (not isinstance(num_sites, int)) or num_sites > 30:
+            raise Exception("cell_num_site is required to be a positive \
+                            integer.")
+        if boundary == "periodic":
+            self.period_bnd_cond_x = 1
+        elif boundary == "aperiodic" or boundary == "hardwall":
+            self.period_bnd_cond_x = 0
+        else:
+            raise Exception("Error in boundary: Only recognized bounday \
+                    options are:\"periodic \",\"aperiodic\" and \"hardwall\" ")
+
+    def __repr__(self):
+        s = ""
+        s += ("Lattice1d_f_HubbardN object: " +
+              "Number of sites = " + str(self.num_sites) +
+              ",\n hopping energy between sites, t = " + str(self.paramT) +
+              ",\n number of spin up fermions = " +
+              str(self.fillingUp) +
+              ",\n number of spin down fermions = " + str(self.fillingDown) +
+              ",\n k - vector sector = " + str(self.k) + "\n")
+        if self.period_bnd_cond_x == 1:
+            s += "Boundary Condition:  Periodic"
+        else:
+            s += "Boundary Condition:  Hardwall"
+        return s
+
+    def Hamiltonian(self, Nmax=2, filling=None, kval=None):
+        """
+        Returns the Hamiltonian for the instance of Lattice1d_bose_Hubbard.
+
+        Parameters
+        ==========
+        filling : int
+            The number of excitations in each basis member.
+        kval : int
+            The index of reciprocal lattice vector specified for each basis
+            member.
+
+        Returns
+        ----------
+        Hamiltonian : qutip.Qobj
+            oper type Quantum object representing the lattice Hamiltonian.
+        basis : qutip.Oobj
+            The basis that the Hamiltonian is formed in.
+        """
+        if filling is None and kval is None:
+            symOpInvariantsUp = np.array([np.zeros(self.latticeSize[0],)])
+            symOpInvariantsUp[0, 0] = 1
+            [indNeighbors, nSites] = getNearestNeighbors(
+                latticeType=self.latticeType, latticeSize=self.latticeSize,
+                boundaryCondition=self.period_bnd_cond_x)
+
+            basisStates_S = createBosonBasis(nSites, Nmax, filling=None)
+            kValue = 0
+            [compDownStatesPerRepr, compInd2ReprDown, normHubbardStates
+             ] = combine2HubbardBasisOnlyTrans(
+                 symOpInvariantsUp, basisStates_S, self.latticeSize, kValue,
+                 self.PP, Nmax)
+            Hamiltonian = calcHamiltonDownOnlyTransBoson(
+                compDownStatesPerRepr, compInd2ReprDown, self.paramT,
+                self.paramU, indNeighbors, normHubbardStates,
+                symOpInvariantsUp, kValue, basisStates_S, self.latticeSize,
+                self.PP, Nmax, Trans=0)
+            bosonBasis = compDownStatesPerRepr[0]
+
+        elif filling is not None and kval is None:
+            symOpInvariantsUp = np.array([np.zeros(self.latticeSize[0],)])
+            symOpInvariantsUp[0, 0] = 1
+            kValue = 0
+            basisStates_S = createBosonBasis(
+                    self.latticeSize[0], Nmax, filling)
+            [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+             ] = combine2HubbardBasisOnlyTrans(
+                 symOpInvariantsUp, basisStates_S, self.latticeSize, kValue,
+                 self.PP, Nmax)
+
+            compDownStatesPerRepr_S = DownStatesPerk
+            compInd2ReprDown_S = Ind2kDown
+            symOpInvariantsUp_S = symOpInvariantsUp
+            normHubbardStates_S = normDownHubbardStatesk
+            [indNeighbors, nSites] = getNearestNeighbors(
+                latticeType=self.latticeType, latticeSize=self.latticeSize,
+                boundaryCondition=self.period_bnd_cond_x)
+            Hamiltonian = calcHamiltonDownOnlyTransBoson(
+                compDownStatesPerRepr_S, compInd2ReprDown_S, self.paramT,
+                self.paramU, indNeighbors, normHubbardStates_S,
+                symOpInvariantsUp_S, kValue, basisStates_S[0],
+                self.latticeSize, self.PP, Nmax, Trans=0)
+            bosonBasis = basisStates_S
+
+        elif filling is not None and kval is not None:
+            symOpInvariantsUp = np.array([np.power(self.PP, np.arange(
+                self.latticeSize[0]))])
+            [indNeighbors, nSites] = getNearestNeighbors(
+                latticeType=self.latticeType, latticeSize=self.latticeSize,
+                boundaryCondition=self.period_bnd_cond_x)
+            kVector = np.arange(start=0, stop=2*np.pi,
+                                step=2 * np.pi / self.latticeSize[0])
+            kValue = kVector[kval]
+            basisStates_S = createBosonBasis(nSites, Nmax, filling)
+            [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+             ] = combine2HubbardBasisOnlyTrans(
+                 symOpInvariantsUp, basisStates_S, self.latticeSize, kValue,
+                 self.PP, Nmax)
+            compDownStatesPerRepr_S = DownStatesPerk
+            compInd2ReprDown_S = Ind2kDown
+
+            symOpInvariantsUp_S = np.array([np.ones(self.latticeSize[0],)])
+            normHubbardStates_S = normDownHubbardStatesk
+            Hamiltonian = calcHamiltonDownOnlyTransBoson(
+                compDownStatesPerRepr_S, compInd2ReprDown_S, self.paramT,
+                self.paramU, indNeighbors, normHubbardStates_S,
+                symOpInvariantsUp_S, kValue, basisStates_S, self.latticeSize,
+                self.PP, Nmax, Trans=1)
+            bosonBasis = compDownStatesPerRepr_S
+
+        elif filling is None and kval is not None:
+            kVector = np.arange(start=0, stop=2*np.pi,
+                                step=2 * np.pi / self.latticeSize[0])
+            symOpInvariantsUp = np.array([np.power(self.PP, np.arange(
+                self.latticeSize[0]))])
+
+            kValue = kVector[kval]
+            basisStates_S = createBosonBasis(
+                    self.latticeSize[0], Nmax, filling=None)
+            [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+             ] = combine2HubbardBasisOnlyTrans(
+                 symOpInvariantsUp, basisStates_S, self.latticeSize, kValue,
+                 self.PP, Nmax)
+            compDownStatesPerRepr_S = DownStatesPerk
+            compInd2ReprDown_S = Ind2kDown
+            symOpInvariantsUp_S = np.array([np.ones(self.latticeSize[0],)])
+
+            normHubbardStates_S = normDownHubbardStatesk
+
+            [indNeighbors, nSites] = getNearestNeighbors(
+                latticeType=self.latticeType, latticeSize=self.latticeSize,
+                boundaryCondition=self.period_bnd_cond_x)
+            Hamiltonian = calcHamiltonDownOnlyTransBoson(
+                compDownStatesPerRepr_S, compInd2ReprDown_S, self.paramT,
+                self.paramU, indNeighbors, normHubbardStates_S,
+                symOpInvariantsUp_S, kValue, basisStates_S, self.latticeSize,
+                self.PP, Nmax, Trans=1)
+            bosonBasis = compDownStatesPerRepr_S
+        return [Qobj(Hamiltonian), bosonBasis]
+
+    def NoSym_DiagTrans(self, filling, Nmax=3):
+        """
+        Computes the unitary matrix that block-diagonalizes the Hamiltonian
+        written in a basis with k-vector symmetry.
+
+        Parameters
+        ==========
+        filling : int
+            The number of excitations in each basis member.
+        Nmax : int
+            The maximum number of bosonic excitations in each site.
+
+        Returns
+        -------
+        Qobj(Usss) : Qobj(csr_matrix)
+            The unitary matrix that block-diagonalizes the Hamiltonian written
+            in a basis with k-vector symmetry.
+        """
+        latticeSize = self.latticeSize
+        PP = self.PP
+        nSites = latticeSize[0]
+        kVector = np.arange(start=0, stop=2 * np.pi, step=2 * np.pi / nSites)
+
+        symOpInvariantsUp = np.array([np.power(PP, np.arange(nSites))])
+        basisStates_S = createBosonBasis(nSites, Nmax, filling=None)
+
+        [nBasisStates, dumpV] = np.shape(basisStates_S)
+        bin2dez = np.arange(nSites-1, -1, -1)
+        bin2dez = np.power(Nmax+1, bin2dez)
+        intDownStates = np.sum(basisStates_S*bin2dez, axis=1)
+
+        Is = 0
+        RowIndexUs = 0
+        sumL = 0
+        cumulIndex = np.zeros(nSites+1, dtype=int)
+        cumulIndex[0] = 0
+        # loop over k-vector
+        for ikVector in range(nSites):
+            kValue = kVector[ikVector]
+            [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+             ] = combine2HubbardBasisOnlyTrans(
+             symOpInvariantsUp, basisStates_S, latticeSize, kValue, PP, Nmax)
+
+            sumL = sumL + np.size(Ind2kDown[0])
+            cumulIndex[ikVector+1] = sumL
+            DownStatesPerk = DownStatesPerk[0]
+            [nReprUp, dumpV] = np.shape(DownStatesPerk)
+
+            for k in range(nReprUp):
+                DownState = DownStatesPerk[k, :]
+                # calculate period
+                for h in range(1, nSites+1, 1):
+                    DownState_S = np.roll(DownState, -h)
+
+                    if (DownState_S == DownState).all():
+                        pn = h
+                        break
+
+                no_of_flips = 0
+                DownState_shifted = DownState
+
+                for m in range(nSites):
+                    DownState_m = np.roll(DownState, -m)
+                    DownState_m_int = np.sum(DownState_m * bin2dez, axis=0)
+
+                    DLT = np.argwhere(intDownStates == DownState_m_int)
+                    ind_down = DLT[:, 0][0]
+
+                    if m > 0:
+                        DownState_shifted = np.roll(DownState_shifted, -1)
+
+                        if np.mod(np.count_nonzero(DownState) + 1, 2):
+                            no_of_flips = no_of_flips + DownState_shifted[-1]
+
+                    else:
+                        no_of_flips = 0
+
+                    NewRI = k + RowIndexUs
+                    NewCI = ind_down
+
+                    NewEn = np.sqrt(pn)/nSites * np.power(
+                        PP, no_of_flips) * np.exp(
+                            -2 * np.pi * 1J / nSites * ikVector * m)
+
+                    if Is == 0:
+                        UssRowIs = np.array([NewRI])
+                        UssColIs = np.array([NewCI])
+                        UssEntries = np.array([NewEn])
+                        Is = 1
+                    elif Is > 0:
+                        DLT = np.argwhere(UssRowIs == NewRI)
+                        iArg1 = DLT[:, 0]
+                        DLT = np.argwhere(UssColIs == NewCI)
+                        iArg2 = DLT[:, 0]
+                        if np.size(np.intersect1d(iArg1, iArg2)):
+                            AtR = np.intersect1d(iArg1, iArg2)
+                            UssEntries[AtR] = UssEntries[AtR] + NewEn
+                        else:
+                            Is = Is + 1
+                            UssRowIs = np.append(UssRowIs, np.array([NewRI]),
+                                                 axis=0)
+                            UssColIs = np.append(UssColIs, np.array([NewCI]),
+                                                 axis=0)
+                            UssEntries = np.append(UssEntries,
+                                                   np.array([NewEn]), axis=0)
+
+            RowIndexUs = RowIndexUs + cumulIndex[
+                ikVector+1] - cumulIndex[ikVector]
+
+        Usss = sparse.csr_matrix((UssEntries, (UssRowIs, UssColIs)),
+                                 shape=(nBasisStates, nBasisStates))
+        return Qobj(Usss)
+
+    def NoSym_DiagTrans_k(self, filling, kval, Nmax=3):
+        """
+        Computes the section of the unitary matrix that computes the
+        block-diagonalized Hamiltonian written in a basis with the given
+        k-vector symmetry.
+
+        Parameters
+        ==========
+        filling : int
+            The number of excitations in each basis member.
+        kval : int
+            The index of wave-vector which the basis members would have the
+            symmetry of.
+        Nmax : int
+            The maximum number of bosonic excitations in each site.
+
+        Returns
+        -------
+        Qobj(Usss) : Qobj(csr_matrix)
+            The section of the unitary matrix that gives the Hamiltonian
+            written in a basis with k-vector symmetry.
+        """
+        latticeSize = self.latticeSize
+        PP = self.PP
+        nSites = latticeSize[0]
+        kVector = np.arange(start=0, stop=2*np.pi, step=2*np.pi/nSites)
+        symOpInvariantsUp = np.array([np.power(PP, np.arange(nSites))])
+        basisStates_S = createBosonBasis(nSites, Nmax, filling=filling)
+
+        [nBasisStates, dumpV] = np.shape(basisStates_S)
+        bin2dez = np.arange(nSites-1, -1, -1)
+        bin2dez = np.power(Nmax+1, bin2dez)
+        intDownStates = np.sum(basisStates_S*bin2dez, axis=1)
+
+        sumL = 0
+        cumulIndex = np.zeros(nSites+1, dtype=int)
+        cumulIndex[0] = 0
+        # loop over k-vector
+        for ikVector in range(nSites):
+            kValue = kVector[ikVector]
+            [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+             ] = combine2HubbardBasisOnlyTrans(
+                 symOpInvariantsUp, basisStates_S, latticeSize, kValue, PP,
+                 Nmax)
+            sumL = sumL + np.size(Ind2kDown[0])
+            cumulIndex[ikVector+1] = sumL
+
+        Is = 0
+        kValue = kVector[kval]
+
+        [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+         ] = combine2HubbardBasisOnlyTrans(
+         symOpInvariantsUp, basisStates_S, latticeSize, kValue, PP, Nmax)
+        DownStatesPerk = DownStatesPerk[0]
+        [nReprUp, dumpV] = np.shape(DownStatesPerk)
+
+        for k in range(nReprUp):
+            DownState = DownStatesPerk[k, :]
+            # calculate period
+            for h in range(1, nSites+1, 1):
+                DownState_S = np.roll(DownState, -h)
+
+                if (DownState_S == DownState).all():
+                    pn = h
+                    break
+
+            no_of_flips = 0
+            DownState_shifted = DownState
+
+            for m in range(nSites):
+                DownState_m = np.roll(DownState, -m)
+                DownState_m_int = np.sum(DownState_m * bin2dez, axis=0)
+
+                DLT = np.argwhere(intDownStates == DownState_m_int)
+                ind_down = DLT[:, 0][0]
+
+                if m > 0:
+                    DownState_shifted = np.roll(DownState_shifted, -1)
+                    if np.mod(np.count_nonzero(DownState)+1, 2):
+                        no_of_flips = no_of_flips + DownState_shifted[-1]
+
+                else:
+                    no_of_flips = 0
+
+                NewRI = k
+                NewCI = ind_down
+
+                NewEn = np.sqrt(pn) / nSites * np.power(
+                    PP, no_of_flips) * np.exp(
+                        -2 * np.pi * 1J / nSites * kval * m)
+
+                if Is == 0:
+                    UssRowIs = np.array([NewRI])
+                    UssColIs = np.array([NewCI])
+                    UssEntries = np.array([NewEn])
+                    Is = 1
+                elif Is > 0:
+                    DLT = np.argwhere(UssRowIs == NewRI)
+                    iArg1 = DLT[:, 0]
+                    DLT = np.argwhere(UssColIs == NewCI)
+                    iArg2 = DLT[:, 0]
+                    if np.size(np.intersect1d(iArg1, iArg2)):
+                        AtR = np.intersect1d(iArg1, iArg2)
+                        UssEntries[AtR] = UssEntries[AtR] + NewEn
+                    else:
+                        Is = Is + 1
+                        UssRowIs = np.append(UssRowIs, np.array([NewRI]),
+                                             axis=0)
+                        UssColIs = np.append(UssColIs, np.array([NewCI]),
+                                             axis=0)
+                        UssEntries = np.append(UssEntries, np.array([NewEn]),
+                                               axis=0)
+
+        Usss = sparse.csr_matrix((UssEntries, (UssRowIs, UssColIs)),
+                                 shape=(cumulIndex[kval+1]-cumulIndex[kval],
+                                        nBasisStates))
+
+        return Qobj(Usss)
+
+    def nums_DiagTrans(self, filling, Nmax=3):
+        """
+        Computes the unitary matrix that block-diagonalizes the Hamiltonian
+        written in a basis without k-vector symmetry to with it.
+
+        Parameters
+        ==========
+        filling : int
+            The number of excitations in each basis member.
+        Nmax : int
+            The maximum number of bosonic excitations in each site.
+
+        Returns
+        -------
+        Qobj(Usss) : Qobj(csr_matrix)
+            The unitary matrix that block-diagonalizes the Hamiltonian written
+            in a basis with k-vector symmetry.
+        """
+        PP = self.PP
+        latticeSize = self.latticeSize
+        PP = self.PP
+        nSites = latticeSize[0]
+        kVector = np.arange(start=0, stop=2*np.pi, step=2*np.pi/nSites)
+
+        symOpInvariantsUp = np.array([np.power(1, np.arange(nSites))])
+        basisStates_S = createBosonBasis(nSites, Nmax, filling=filling)
+        [nBasisStates, dumpV] = np.shape(basisStates_S)
+        bin2dez = np.arange(nSites-1, -1, -1)
+        bin2dez = np.power(Nmax+1, bin2dez)
+        intDownStates = np.sum(basisStates_S*bin2dez, axis=1)
+
+        Is = 0
+        RowIndexUs = 0
+        sumL = 0
+        cumulIndex = np.zeros(nSites+1, dtype=int)
+        cumulIndex[0] = 0
+        # loop over k-vector
+        for ikVector in range(nSites):
+            kValue = kVector[ikVector]
+
+            [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+             ] = combine2HubbardBasisOnlyTrans(
+                 symOpInvariantsUp, basisStates_S, latticeSize, kValue, PP,
+                 Nmax)
+            sumL = sumL + np.size(Ind2kDown[0])
+            cumulIndex[ikVector+1] = sumL
+            DownStatesPerk = DownStatesPerk[0]
+            [nReprUp, dumpV] = np.shape(DownStatesPerk)
+
+            for k in range(nReprUp):
+                DownState = DownStatesPerk[k, :]
+                # calculate period
+                for h in range(1, nSites+1, 1):
+                    DownState_S = np.roll(DownState, -h)
+
+                    if (DownState_S == DownState).all():
+                        pn = h
+                        break
+
+                no_of_flips = 0
+                DownState_shifted = DownState
+
+                for m in range(nSites):
+                    DownState_m = np.roll(DownState, -m)
+                    DownState_m_int = np.sum(DownState_m * bin2dez, axis=0)
+
+                    DLT = np.argwhere(intDownStates == DownState_m_int)
+                    ind_down = DLT[:, 0][0]
+
+                    if m > 0:
+                        DownState_shifted = np.roll(DownState_shifted, -1)
+
+                        if np.mod(np.count_nonzero(DownState) + 1, 2):
+                            no_of_flips = no_of_flips + DownState_shifted[-1]
+
+                    else:
+                        no_of_flips = 0
+
+                    NewRI = k + RowIndexUs
+                    NewCI = ind_down
+                    NewEn = np.sqrt(pn)/nSites * np.power(
+                        PP, no_of_flips) * np.exp(
+                            -2 * np.pi * 1J / nSites * ikVector * m)
+
+                    if Is == 0:
+                        UssRowIs = np.array([NewRI])
+                        UssColIs = np.array([NewCI])
+                        UssEntries = np.array([NewEn])
+                        Is = 1
+                    elif Is > 0:
+                        DLT = np.argwhere(UssRowIs == NewRI)
+                        iArg1 = DLT[:, 0]
+                        DLT = np.argwhere(UssColIs == NewCI)
+                        iArg2 = DLT[:, 0]
+                        if np.size(np.intersect1d(iArg1, iArg2)):
+                            AtR = np.intersect1d(iArg1, iArg2)
+                            UssEntries[AtR] = UssEntries[AtR] + NewEn
+                        else:
+                            Is = Is + 1
+                            UssRowIs = np.append(UssRowIs, np.array([NewRI]),
+                                                 axis=0)
+                            UssColIs = np.append(UssColIs,
+                                                 np.array([NewCI]), axis=0)
+                            UssEntries = np.append(UssEntries,
+                                                   np.array([NewEn]), axis=0)
+
+            RowIndexUs = RowIndexUs + cumulIndex[ikVector+1] - cumulIndex[
+                ikVector]
+
+        Usss = sparse.csr_matrix((UssEntries, (UssRowIs, UssColIs)),
+                                 shape=(nBasisStates, nBasisStates))
+
+        return Qobj(Usss)
+
+    def nums_DiagTrans_k(self, filling, kval, Nmax=3):
+        """
+        Computes the section of the unitary matrix that computes the
+        block-diagonalized Hamiltonian written in a basis with the given
+        k-vector and number symmetry.
+
+        Parameters
+        ==========
+        filling : int
+            The specified number of excitations in each basis member.
+        kval : int
+            The index of wave-vector which the basis members would have the
+            symmetry of.
+        Nmax : int
+            The maximum number of bosonic excitations in each site.
+
+        Returns
+        -------
+        Qobj(Usss) : Qobj(csr_matrix)
+            The section of the unitary matrix that gives the Hamiltonian
+            written in a basis with k-vector symmetry.
+        """
+        latticeSize = self.latticeSize
+        PP = self.PP
+        nSites = latticeSize[0]
+        kVector = np.arange(start=0, stop=2*np.pi, step=2*np.pi/nSites)
+
+        symOpInvariantsUp = np.array([np.power(1, np.arange(nSites))])
+        basisStates_S = createBosonBasis(nSites, Nmax, filling=filling)
+
+        [nBasisStates, dumpV] = np.shape(basisStates_S)
+        bin2dez = np.arange(nSites-1, -1, -1)
+        bin2dez = np.power(Nmax+1, bin2dez)
+        intDownStates = np.sum(basisStates_S*bin2dez, axis=1)
+
+        sumL = 0
+        cumulIndex = np.zeros(nSites+1, dtype=int)
+        cumulIndex[0] = 0
+        # loop over k-vector
+        for ikVector in range(nSites):
+            kValue = kVector[ikVector]
+            [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+             ] = combine2HubbardBasisOnlyTrans(
+             symOpInvariantsUp, basisStates_S, latticeSize, kValue, PP, Nmax)
+            sumL = sumL + np.size(Ind2kDown[0])
+            cumulIndex[ikVector+1] = sumL
+
+        Is = 0
+        kValue = kVector[kval]
+
+        [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+         ] = combine2HubbardBasisOnlyTrans(
+         symOpInvariantsUp, basisStates_S, latticeSize, kValue, PP, Nmax)
+        DownStatesPerk = DownStatesPerk[0]
+        [nReprUp, dumpV] = np.shape(DownStatesPerk)
+
+        for k in range(nReprUp):
+            DownState = DownStatesPerk[k, :]
+            # calculate period
+            for h in range(1, nSites+1, 1):
+                DownState_S = np.roll(DownState, -h)
+
+                if (DownState_S == DownState).all():
+                    pn = h
+                    break
+
+            no_of_flips = 0
+            DownState_shifted = DownState
+
+            for m in range(nSites):
+                DownState_m = np.roll(DownState, -m)
+                DownState_m_int = np.sum(DownState_m * bin2dez, axis=0)
+
+                DLT = np.argwhere(intDownStates == DownState_m_int)
+                ind_down = DLT[:, 0][0]
+
+                if m > 0:
+                    DownState_shifted = np.roll(DownState_shifted, -1)
+
+                    if np.mod(np.count_nonzero(DownState)+1, 2):
+                        # fillingUp is even
+                        no_of_flips = no_of_flips + DownState_shifted[-1]
+
+                else:
+                    no_of_flips = 0
+
+                NewRI = k
+                NewCI = ind_down
+
+                NewEn = np.sqrt(pn)/nSites * np.power(
+                    PP, no_of_flips) * np.exp(
+                        -2 * np.pi * 1J / nSites * kval * m)
+
+                if Is == 0:
+                    UssRowIs = np.array([NewRI])
+                    UssColIs = np.array([NewCI])
+                    UssEntries = np.array([NewEn])
+                    Is = 1
+                elif Is > 0:
+                    DLT = np.argwhere(UssRowIs == NewRI)
+                    iArg1 = DLT[:, 0]
+                    DLT = np.argwhere(UssColIs == NewCI)
+                    iArg2 = DLT[:, 0]
+                    if np.size(np.intersect1d(iArg1, iArg2)):
+                        AtR = np.intersect1d(iArg1, iArg2)
+                        UssEntries[AtR] = UssEntries[AtR] + NewEn
+                    else:
+                        Is = Is + 1
+                        UssRowIs = np.append(UssRowIs, np.array([NewRI]),
+                                             axis=0)
+                        UssColIs = np.append(UssColIs, np.array([NewCI]),
+                                             axis=0)
+                        UssEntries = np.append(UssEntries, np.array([NewEn]),
+                                               axis=0)
+
+        Usss = sparse.csr_matrix((UssEntries, (UssRowIs, UssColIs)), shape=(
+            cumulIndex[kval+1]-cumulIndex[kval], nBasisStates))
+
+        return Qobj(Usss)
+
+
+class Lattice1d_2c_hcb_Hubbard():
+    """A class for representing a 1d two component hardcore boson Hubbard
+    model.
+
+    The Lattice1d_2c_hcb_Hubbard class is defined with a specific unit cells
+    and parameters of the two component hardcore boson Hubbard model. It can
+    return Hamiltonians written in a chosen (with specific symmetry) basis and
+    unitary transformations that can be used in switching between them.
+
+    Parameters
+    ----------
+    num_sites : int
+        The number of sites in the fermi Hubbard lattice.
+    PP : int
+        The exchange phase factor for particles, -1 for fermions
+    boundary : str
+        Specification of the type of boundary the crystal is defined with.
+    t : float
+        The nearest neighbor hopping integral.
+    Uab : float
+        The onsite interaction strngth between the two species.
+
+    Attributes
+    ----------
+    num_sites : int
+        The number of sites in the fermi Hubbard lattice.
+    period_bnd_cond_x : int
+        1 indicates "periodic" and 0 indicates "hardwall" boundary condition
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    """
+    def __init__(self, num_sites=10, boundary="periodic", t=1, Uab=1):
+        self.PP = 1
+        self.paramT = t
+        self.paramU = Uab
+        self.latticeSize = [num_sites]
+
+        if (not isinstance(num_sites, int)) or num_sites > 18:
+            raise Exception("cell_num_site is required to be a positive \
+                            integer.")
+        if boundary == "periodic":
+            self.period_bnd_cond_x = 1
+        elif boundary == "aperiodic" or boundary == "hardwall":
+            self.period_bnd_cond_x = 0
+        else:
+            raise Exception("Error in boundary: Only recognized bounday \
+                    options are:\"periodic \",\"aperiodic\" and \"hardwall\" ")
+
+    def __repr__(self):
+        s = ""
+        s += ("Lattice1d_f_HubbardN object: " +
+              "Number of sites = " + str(self.num_sites) +
+              ",\n hopping energy between sites, t = " + str(self.paramT) +
+              ",\n on-site interaction energy, U = " +
+              str(self.U) +
+              ",\n number of spin up fermions = " +
+              str(self.fillingUp) +
+              ",\n number of spin down fermions = " + str(self.fillingDown) +
+              ",\n k - vector sector = " + str(self.k) + "\n")
+        if self.period_bnd_cond_x == 1:
+            s += "Boundary Condition:  Periodic"
+        else:
+            s += "Boundary Condition:  Hardwall"
+        return s
+
+    def Hamiltonian(self, fillingUp=None, fillingDown=None, kval=None):
+        """
+        Returns the Hamiltonian for the instance of Lattice1d_2c_hcb_Hubbard.
+
+        filling : int
+            The number of excitations in each basis member.
+        kval : int
+            The index of reciprocal lattice vector specified for each basis
+            member.
+
+        Returns
+        ----------
+        Hamiltonian : qutip.Qobj
+            oper type Quantum object representing the lattice Hamiltonian.
+        basis : qutip.Oobj
+            The basis that the Hamiltonian is formed in.
+        """
+        if fillingUp is None and fillingDown is None and kval is None:
+            Hamiltonian_list = self._NoSym_fermionic_Hubbard_chain()
+        elif fillingUp is not None and fillingDown is not None and (
+                kval is None):
+            Hamiltonian_list = self._Only_Nums_fermionic_Hubbard_chain(
+                fillingUp, fillingDown)
+        elif fillingUp is not None and fillingDown is not None and (
+                kval is not None):
+            Hamiltonian_list = self._Nums_Trans_fermionic_Hubbard_chain(
+                fillingUp, fillingDown, kval)
+        elif fillingUp is None and fillingDown is None and kval is not None:
+            Hamiltonian_list = self._Only_Trans_fermionic_Hubbard_chain(kval)
+
+        return Hamiltonian_list
+
+    def _Nums_Trans_fermionic_Hubbard_chain(self, fillingUp, fillingDown,
+                                            kval):
+        """
+        Calculates the Hamiltonian in a basis with number and k-vector symmetry
+        specified.
+
+        fillingUp : int
+            The number of spin-up excitations in each basis member.
+        fillingDown : int
+            The number of spin-down excitations in each basis member.
+        kval : int
+            The index of reciprocal lattice vector specified for each basis
+            member.
+
+        Returns
+        -------
+        Qobj(Hamk) : Qobj(csr_matrix)
+            The Hamiltonian.
+        basisReprUp : int
+            The spin-up representations that are consistent with the k-vector
+            symmetry.
+        compDownStatesPerRepr : numpy 2d array
+            Each row indicates a basis vector chosen in the number and k-vector
+            symmetric basis.
+        normHubbardStates : dict of 2d array of ints
+            The normalized basis states in whichthe Hamiltonian is formed.
+        """
+        latticeType = 'cubic'
+        [indNeighbors, nSites] = getNearestNeighbors(
+            latticeType=latticeType, latticeSize=self.latticeSize,
+            boundaryCondition=self.period_bnd_cond_x)
+
+        nStatesUp = ncr(nSites, fillingUp)
+        nStatesDown = ncr(nSites, fillingDown)
+        nSites = self.latticeSize[0]
+        kVector = np.arange(start=0, stop=2 * np.pi, step=2 * np.pi / nSites)
+        [basisStatesUp, intStatesUp, indOnesUp
+         ] = createHeisenbergBasis(nStatesUp, nSites, fillingUp)
+        [basisStatesDown, integerBasisDown, indOnesDown
+         ] = createHeisenbergBasis(nStatesDown, nSites, fillingDown)
+
+        [basisReprUp, symOpInvariantsUp, index2ReprUp, symOp2ReprUp
+         ] = findReprOnlyTrans(basisStatesUp, self.latticeSize, self.PP)
+        bin2dez = np.arange(nSites-1, -1, -1)
+        bin2dez = np.power(2, bin2dez)
+        intDownStates = np.sum(basisStatesDown*bin2dez, axis=1)
+        intUpStates = np.sum(basisStatesUp*bin2dez, axis=1)
+        [nBasisStatesDown, dumpV] = np.shape(basisStatesDown)
+        [nBasisStatesUp, dumpV] = np.shape(basisStatesUp)
+        kValue = kVector[kval]
+
+        [compDownStatesPerRepr, compInd2ReprDown, normHubbardStates
+         ] = combine2HubbardBasisOnlyTrans(
+         symOpInvariantsUp, basisStatesDown, self.latticeSize, kValue, self.PP,
+         Nmax=1)
+
+        H_down = calcHamiltonDownOnlyTrans(
+            compDownStatesPerRepr, compInd2ReprDown, self.paramT,
+            indNeighbors, normHubbardStates, symOpInvariantsUp, kValue,
+            basisStatesDown, self.latticeSize, self.PP)
+        H_up = calcHamiltonUpOnlyTrans(
+                basisReprUp, compDownStatesPerRepr, self.paramT, indNeighbors,
+                normHubbardStates, symOpInvariantsUp, kValue, index2ReprUp,
+                symOp2ReprUp, intStatesUp, self.latticeSize, self.PP)
+        H_diag = calcHubbardDiag(
+            basisReprUp, normHubbardStates, compDownStatesPerRepr, self.paramU)
+
+        Hamk = H_diag + H_up + H_down
+        vals, vecs = eigs(Hamk, k=1, which='SR')
+        Hamk = Qobj(Hamk)
+        return [Hamk, basisReprUp, compDownStatesPerRepr, normHubbardStates]
+
+    def _NoSym_fermionic_Hubbard_chain(self):
+        """
+        Calculates the Hamiltonian in a basis without any number and k-vector
+        symmetry specified.
+
+        Returns
+        -------
+        Qobj(Hamk) : Qobj(csr_matrix)
+            The Hamiltonian.
+        BasisStatesUp : numpy 2d array
+            The spin-up basis states.
+        BasisStatesDown : numpy 2d array
+            The spin-down basis states.
+        normHubbardStates : dict of 2d array of ints
+            The normalized basis states in which the Hamiltonian is formed.
+        """
+        latticeType = 'cubic'
+        [indNeighbors, nSites] = getNearestNeighbors(
+            latticeType=latticeType, latticeSize=self.latticeSize,
+            boundaryCondition=self.period_bnd_cond_x)
+        basisStatesUp = createHeisenbergfullBasis(nSites)
+        basisStatesDown = createHeisenbergfullBasis(nSites)
+        [nBasisStatesDown, dumpV] = np.shape(basisStatesDown)
+        [nBasisStatesUp, dumpV] = np.shape(basisStatesUp)
+        nHubbardStates = nBasisStatesDown * nBasisStatesUp
+        H_diag_NS = Uterms_hamiltonDiagNoSym(
+                basisStatesUp, basisStatesDown, self.paramU)
+        H_down_NS = HamiltonDownNoSym(
+                basisStatesDown, nBasisStatesUp, self.paramT, indNeighbors,
+                self.PP)
+        H_up_NS = hamiltonUpNoSyms(
+                basisStatesUp, basisStatesDown, self.paramT, indNeighbors,
+                self.PP)
+
+        H_NS = H_diag_NS + H_down_NS + H_up_NS
+        normHubbardStates = np.ones((nHubbardStates), dtype=complex)
+
+        return [Qobj(H_NS), basisStatesUp, basisStatesDown, normHubbardStates]
+
+    def _Only_Trans_fermionic_Hubbard_chain(self, kval):
+        """
+        Calculates the Hamiltonian in a basis with a k-vector symmetry
+        specified.
+
+        kval : int
+            The index of reciprocal lattice vector specified for each basis
+            member.
+        Returns
+        -------
+        Qobj(Hamk) : Qobj(csr_matrix)
+            The Hamiltonian.
+        basisReprUp : int
+            The spin-up representations that are consistent with the k-vector
+            symmetry.
+        compDownStatesPerRepr : numpy 2d array
+            Each row indicates a basis vector chosen in the number and k-vector
+            symmetric basis.
+        normHubbardStates : dict of 2d array of ints
+            The normalized basis states in whichthe Hamiltonian is formed.
+        """
+        latticeType = 'cubic'
+        [indNeighbors, nSites] = getNearestNeighbors(
+            latticeType=latticeType, latticeSize=self.latticeSize,
+            boundaryCondition=self.period_bnd_cond_x)
+        basisStatesUp1 = createHeisenbergfullBasis(nSites)
+        basisStatesDown1 = createHeisenbergfullBasis(nSites)
+        [nBasisStatesDown1, dumpV] = np.shape(basisStatesDown1)
+        [nBasisStatesUp1, dumpV] = np.shape(basisStatesUp1)
+        nHubbardStates1 = nBasisStatesDown1 * nBasisStatesUp1
+
+        kVector = np.arange(start=0, stop=2*np.pi, step=2*np.pi/nSites)
+        [basisReprUp1, symOpInvariantsUp1, index2ReprUp1, symOp2ReprUp1
+         ] = findReprOnlyTrans(basisStatesUp1, self.latticeSize, self.PP)
+        bin2dez = np.arange(nSites-1, -1, -1)
+        bin2dez = np.power(2, bin2dez)
+        intStatesDown1 = np.sum(basisStatesDown1*bin2dez, axis=1)
+        intStatesUp1 = np.sum(basisStatesUp1*bin2dez, axis=1)
+        kValue = kVector[kval]
+        [compDownStatesPerRepr1, compInd2ReprDown1, normHubbardStates1
+         ] = combine2HubbardBasisOnlyTrans(
+         symOpInvariantsUp1, basisStatesDown1, self.latticeSize, kValue,
+         self.PP, Nmax=1)
+        H_down = calcHamiltonDownOnlyTrans(
+                compDownStatesPerRepr1, compInd2ReprDown1, self.paramT,
+                indNeighbors, normHubbardStates1, symOpInvariantsUp1, kValue,
+                basisStatesDown1, self.latticeSize, self.PP)
+        H_up = calcHamiltonUpOnlyTrans(
+                basisReprUp1, compDownStatesPerRepr1, self.paramT,
+                indNeighbors, normHubbardStates1, symOpInvariantsUp1, kValue,
+                index2ReprUp1, symOp2ReprUp1, intStatesUp1, self.latticeSize,
+                self.PP)
+        H_diag = calcHubbardDiag(
+                basisReprUp1, normHubbardStates1, compDownStatesPerRepr1,
+                self.paramU)
+
+        Hamk = H_diag + H_up + H_down
+
+        return [Qobj(Hamk), basisReprUp1, compDownStatesPerRepr1,
+                normHubbardStates1]
+
+    def _Only_Nums_fermionic_Hubbard_chain(self, fillingUp, fillingDown):
+        """
+        Calculates the Hamiltonian in a basis with number symmetry specified.
+
+        fillingUp : int
+            The number of spin-up excitations in each basis member.
+        fillingDown : int
+            The number of spin-down excitations in each basis member.
+
+        Returns
+        -------
+        Qobj(Hamk) : Qobj(csr_matrix)
+            The Hamiltonian.
+        BasisStatesUp : numpy 2d array
+            The spin-up basis states.
+        BasisStatesDown : numpy 2d array
+            The spin-down basis states.
+        normHubbardStates : dict of 2d array of ints
+            The normalized basis states in which the Hamiltonian is formed.
+        """
+#        PP = -1
+        latticeType = 'cubic'
+        [indNeighbors, nSites] = getNearestNeighbors(
+            latticeType=latticeType, latticeSize=self.latticeSize,
+            boundaryCondition=self.period_bnd_cond_x)
+
+        nStatesUp = ncr(nSites, fillingUp)
+        nStatesDown = ncr(nSites, fillingDown)
+        [basisStatesUp, intStatesUp, indOnesUp
+         ] = createHeisenbergBasis(nStatesUp, nSites, fillingUp)
+        [basisStatesDown, integerBasisDown, indOnesDown
+         ] = createHeisenbergBasis(nStatesDown, nSites, fillingDown)
+        [nBasisStatesDown, dumpV] = np.shape(basisStatesDown)
+        [nBasisStatesUp, dumpV] = np.shape(basisStatesUp)
+
+        H_diag_NS = Uterms_hamiltonDiagNoSym(
+                basisStatesUp, basisStatesDown, self.paramU)
+        H_down_NS = HamiltonDownNoSym(
+                basisStatesDown, nBasisStatesUp, self.paramT, indNeighbors,
+                self.PP)
+        H_up_NS = hamiltonUpNoSyms(
+                basisStatesUp, basisStatesDown, self.paramT, indNeighbors,
+                self.PP)
+
+        H_NS = H_diag_NS + H_down_NS + H_up_NS
+        normHubbardStates = np.ones((nStatesUp * nStatesDown), dtype=complex)
+        return [Qobj(H_NS), basisStatesUp, basisStatesDown, normHubbardStates]
+
+    def NoSym_DiagTrans(self):
+        """
+        Calculates the unitary transformation operator that block diagonalizes
+        the Hamiltonian with translational symmetry from the basis of no
+        symmmetry.
+
+        Returns
+        -------
+        Usss : Qobj()
+            The unitary operator
+        """
+        nSites = self.latticeSize[0]
+        basisStatesUp = createHeisenbergfullBasis(nSites)
+        basisStatesDown = createHeisenbergfullBasis(nSites)
+        Usss = UnitaryTrans(
+                self.latticeSize, basisStatesUp, basisStatesDown, PP=1)
+        return Usss
+
+    def NoSym_DiagTrans_k(self, kval=0):
+        """
+        Calculates part of the unitary transformation operator that block
+        diagonalizes the Hamiltonian with translational symmetry at a specific
+        k-vector.
+
+        Returns
+        -------
+        Usss : Qobj()
+            The part of the unitary operator
+        """
+        nSites = self.latticeSize[0]
+        basisStatesUp = createHeisenbergfullBasis(nSites)
+        basisStatesDown = createHeisenbergfullBasis(nSites)
+        Usss_k = UnitaryTrans_k(
+                self.latticeSize, basisStatesUp, basisStatesDown, kval, PP=1)
+        return Usss_k
+
+    def nums_DiagTrans(self, fillingUp=2, fillingDown=2):
+        """
+        Calculates the unitary transformation operator that block diagonalizes
+        the Hamiltonian with translational symmetry from the basis of number
+        specified symmetry.
+
+        Returns
+        -------
+        Usss : Qobj()
+            The unitary operator
+        """
+        nSites = self.latticeSize[0]
+        nStatesUp = ncr(nSites, fillingUp)
+        nStatesDown = ncr(nSites, fillingDown)
+        [basisStatesUp_n, intStatesUp, indOnesUp] = createHeisenbergBasis(
+            nStatesUp, nSites, fillingUp)
+        [basisStatesDown_n, integerBasisDown, indOnesDown
+         ] = createHeisenbergBasis(nStatesDown, nSites, fillingDown)
+
+        Usss_n = UnitaryTrans(
+                self.latticeSize, basisStatesUp_n, basisStatesDown_n, PP=1)
+        return Usss_n
+
+    def nums_DiagTrans_k(self, fillingUp=2, fillingDown=2, kval=0):
+        """
+        Calculates part of the unitary transformation operator that block
+        diagonalizes the Hamiltonian with translational symmetry at a specific
+        k-vector.
+
+        Returns
+        -------
+        Usss : Qobj()
+            The part of the unitary operator
+        """
+        nSites = self.latticeSize[0]
+        nStatesUp = ncr(nSites, fillingUp)
+        nStatesDown = ncr(nSites, fillingDown)
+        [basisStatesUp_n, intStatesUp, indOnesUp] = createHeisenbergBasis(
+            nStatesUp, nSites, fillingUp)
+        [basisStatesDown_n, integerBasisDown, indOnesDown
+         ] = createHeisenbergBasis(nStatesDown, nSites, fillingDown)
+
+        Usss_nk = UnitaryTrans_k(
+                self.latticeSize, basisStatesUp_n, basisStatesDown_n, kval,
+                PP=1)
+        return Usss_nk

--- a/qutip_lattice/fermions_mp.py
+++ b/qutip_lattice/fermions_mp.py
@@ -1,0 +1,1112 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, The QuTiP Project.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+from scipy.sparse import (csr_matrix)
+import scipy.io as spio
+from qutip import (Qobj, tensor, basis, qeye, isherm, sigmax, sigmay, sigmaz,
+                   create, destroy)
+
+import numpy as np
+
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    pass
+
+
+from scipy import sparse
+from scipy.sparse.linalg import eigs
+import operator as op
+from functools import reduce
+import copy
+from numpy import asarray
+import math
+from .tran_sym_functions import *
+from .lattice_operators import *
+from .spinless_functions import *
+
+__all__ = ['Lattice1d_fermions', 'Lattice1d_fermi_Hubbard']
+
+class Lattice1d_fermi_Hubbard():
+    """A class for representing a 1d fermi Hubbard model.
+
+    The Lattice1d_fermi_Hubbard class is defined with a specific unit cells
+    and parameters of the extended fermi Hubbard model. It can return
+    Hamiltonians written in a chosen (with specific symmetry) basis and unitary
+    transformations that can be used in switching between them.
+
+    Parameters
+    ----------
+    num_sites : int
+        The number of sites in the fermi Hubbard lattice.
+    PP : int
+        The exchange phase factor for particles, -1 for fermions
+    boundary : str
+        Specification of the type of boundary the crystal is defined with.
+    t : float
+        The nearest neighbor hopping integral.
+    U : float
+        The onsite interaction strngth of the Hubbard model.
+    V : float
+        The nearest neighbor interaction strength of the extended Hubbard model
+
+    Attributes
+    ----------
+    num_sites : int
+        The number of sites in the fermi Hubbard lattice.
+    period_bnd_cond_x : int
+        1 indicates "periodic" and 0 indicates "hardwall" boundary condition
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    """
+    def __init__(self, num_sites=10, boundary="periodic", t=1, U=1, V=1):
+        self.PP = -1
+        self.paramT = t
+        self.paramU = U
+        self.paramV = V
+        self.latticeSize = [num_sites]
+
+        if (not isinstance(num_sites, int)) or num_sites > 38:
+            raise Exception("cell_num_site is required to be a positive \
+                            integer.")
+        if boundary == "periodic":
+            self.period_bnd_cond_x = 1
+        elif boundary == "aperiodic" or boundary == "hardwall":
+            self.period_bnd_cond_x = 0
+        else:
+            raise Exception("Error in boundary: Only recognized bounday \
+                    options are:\"periodic \",\"aperiodic\" and \"hardwall\" ")
+
+    def __repr__(self):
+        s = ""
+        s += ("Lattice1d_f_HubbardN object: " +
+              "Number of sites = " + str(self.num_sites) +
+              ",\n hopping energy between sites, t = " + str(self.paramT) +
+              ",\n on-site interaction energy, U = " +
+              str(self.U) +
+              ",\n number of spin up fermions = " +
+              str(self.fillingUp) +
+              ",\n number of spin down fermions = " + str(self.fillingDown) +
+              ",\n k - vector sector = " + str(self.k) + "\n")
+        if self.period_bnd_cond_x == 1:
+            s += "Boundary Condition:  Periodic"
+        else:
+            s += "Boundary Condition:  Hardwall"
+        return s
+
+    def Hamiltonian(self, fillingUp=None, fillingDown=None, kval=None):
+        """
+        Returns the Hamiltonian for the instance of Lattice1d_fermi_Hubbard.
+
+        filling : int
+            The number of excitations in each basis member.
+        kval : int
+            The index of reciprocal lattice vector specified for each basis
+            member.
+
+        Returns
+        ----------
+        Hamiltonian : qutip.Qobj
+            oper type Quantum object representing the lattice Hamiltonian.
+        basis : qutip.Oobj
+            The basis that the Hamiltonian is formed in.
+        """
+        if fillingUp is None and fillingDown is None and kval is None:
+            Hamiltonian_list = self._NoSym_fermionic_Hubbard_chain()
+        elif fillingUp is not None and fillingDown is not None and (
+                kval is None):
+            Hamiltonian_list = self._Only_Nums_fermionic_Hubbard_chain(
+                fillingUp, fillingDown)
+        elif fillingUp is not None and fillingDown is not None and (
+                kval is not None):
+            Hamiltonian_list = self._Nums_Trans_fermionic_Hubbard_chain(
+                fillingUp, fillingDown, kval)
+        elif fillingUp is None and fillingDown is None and kval is not None:
+            Hamiltonian_list = self._Only_Trans_fermionic_Hubbard_chain(kval)
+
+        return Hamiltonian_list
+
+    def _Nums_Trans_fermionic_Hubbard_chain(self, fillingUp, fillingDown,
+                                            kval):
+        """
+        Calculates the Hamiltonian in a basis with number and k-vector symmetry
+        specified.
+
+        fillingUp : int
+            The number of spin-up excitations in each basis member.
+        fillingDown : int
+            The number of spin-down excitations in each basis member.
+        kval : int
+            The index of reciprocal lattice vector specified for each basis
+            member.
+        Returns
+        -------
+        Qobj(Hamk) : Qobj(csr_matrix)
+            The Hamiltonian.
+        basisReprUp : int
+            The spin-up representations that are consistent with the k-vector
+            symmetry.
+        compDownStatesPerRepr : numpy 2d array
+            Each row indicates a basis vector chosen in the number and k-vector
+            symmetric basis.
+        normHubbardStates : dict of 2d array of ints
+            The normalized basis states in whichthe Hamiltonian is formed.
+        """
+        latticeType = 'cubic'
+        [indNeighbors, nSites] = getNearestNeighbors(
+            latticeType=latticeType, latticeSize=self.latticeSize,
+            boundaryCondition=self.period_bnd_cond_x)
+
+        nStatesUp = ncr(nSites, fillingUp)
+        nStatesDown = ncr(nSites, fillingDown)
+        nSites = self.latticeSize[0]
+        kVector = np.arange(start=0, stop=2 * np.pi, step=2 * np.pi / nSites)
+        [basisStatesUp, intStatesUp, indOnesUp
+         ] = createHeisenbergBasis(nStatesUp, nSites, fillingUp)
+        [basisStatesDown, integerBasisDown, indOnesDown
+         ] = createHeisenbergBasis(nStatesDown, nSites, fillingDown)
+
+        [basisReprUp, symOpInvariantsUp, index2ReprUp, symOp2ReprUp
+         ] = findReprOnlyTrans(basisStatesUp, self.latticeSize, self.PP)
+        bin2dez = np.arange(nSites-1, -1, -1)
+        bin2dez = np.power(2, bin2dez)
+        intDownStates = np.sum(basisStatesDown*bin2dez, axis=1)
+        intUpStates = np.sum(basisStatesUp*bin2dez, axis=1)
+        [nBasisStatesDown, dumpV] = np.shape(basisStatesDown)
+        [nBasisStatesUp, dumpV] = np.shape(basisStatesUp)
+        kValue = kVector[kval]
+
+        [compDownStatesPerRepr, compInd2ReprDown, normHubbardStates
+         ] = combine2HubbardBasisOnlyTrans(
+         symOpInvariantsUp, basisStatesDown, self.latticeSize, kValue, self.PP,
+         Nmax=1)
+        H_down = calcHamiltonDownOnlyTrans(
+            compDownStatesPerRepr, compInd2ReprDown, self.paramT, indNeighbors,
+            normHubbardStates, symOpInvariantsUp, kValue, basisStatesDown,
+            self.latticeSize, self.PP)
+        H_up = calcHamiltonUpOnlyTrans(
+            basisReprUp, compDownStatesPerRepr, self.paramT, indNeighbors,
+            normHubbardStates, symOpInvariantsUp, kValue, index2ReprUp,
+            symOp2ReprUp, intStatesUp, self.latticeSize, self.PP)
+        H_diag = calcHubbardDiag(
+            basisReprUp, normHubbardStates, compDownStatesPerRepr, self.paramU)
+        H_diagN = Vterms_hamiltonDiagNumTrans(
+            basisReprUp, compDownStatesPerRepr, self.paramT, indNeighbors,
+            kValue, self.paramV, self.PP)
+        Hamk = H_diag + H_diagN + H_up + H_down
+        Hamk = Qobj(Hamk)
+        return [Hamk, basisReprUp, compDownStatesPerRepr, normHubbardStates]
+
+    def _NoSym_fermionic_Hubbard_chain(self):
+        """
+        Calculates the Hamiltonian in a basis without any number and k-vector
+        symmetry specified.
+
+        Returns
+        -------
+        Qobj(Hamk) : Qobj(csr_matrix)
+            The Hamiltonian.
+        BasisStatesUp : numpy 2d array
+            The spin-up basis states.
+        BasisStatesDown : numpy 2d array
+            The spin-down basis states.
+        normHubbardStates : dict of 2d array of ints
+            The normalized basis states in which the Hamiltonian is formed.
+        """
+        latticeType = 'cubic'
+        [indNeighbors, nSites] = getNearestNeighbors(
+            latticeType=latticeType, latticeSize=self.latticeSize,
+            boundaryCondition=self.period_bnd_cond_x)
+        basisStatesUp = createHeisenbergfullBasis(nSites)
+        basisStatesDown = createHeisenbergfullBasis(nSites)
+        [nBasisStatesDown, dumpV] = np.shape(basisStatesDown)
+        [nBasisStatesUp, dumpV] = np.shape(basisStatesUp)
+        nHubbardStates = nBasisStatesDown * nBasisStatesUp
+        H_diag_NS = Uterms_hamiltonDiagNoSym(
+            basisStatesUp, basisStatesDown, self.paramU)
+        H_down_NS = HamiltonDownNoSym(
+                basisStatesDown, nBasisStatesUp, self.paramT, indNeighbors,
+                self.PP)
+        H_up_NS = hamiltonUpNoSyms(
+                basisStatesUp, basisStatesDown, self.paramT, indNeighbors,
+                self.PP)
+        H_diagN_NS = Vterms_hamiltonDiagNoSym(
+                basisStatesUp, basisStatesDown, self.paramT, indNeighbors,
+                self.paramV, self.PP)
+
+        H_NS1 = H_diag_NS + H_down_NS + H_up_NS + H_diagN_NS
+        normHubbardStates = np.ones((nHubbardStates), dtype=complex)
+        return [Qobj(H_NS1), basisStatesUp, basisStatesDown, normHubbardStates]
+
+    def _Only_Trans_fermionic_Hubbard_chain(self, kval):
+        """
+        Calculates the Hamiltonian in a basis with a k-vector symmetry
+        specified.
+
+        kval : int
+            The index of reciprocal lattice vector specified for each basis
+            member.
+        Returns
+        -------
+        Qobj(Hamk) : Qobj(csr_matrix)
+            The Hamiltonian.
+        basisReprUp : int
+            The spin-up representations that are consistent with the k-vector
+            symmetry.
+        compDownStatesPerRepr : numpy 2d array
+            Each row indicates a basis vector chosen in the number and k-vector
+            symmetric basis.
+        normHubbardStates : dict of 2d array of ints
+            The normalized basis states in whichthe Hamiltonian is formed.
+        """
+        latticeType = 'cubic'
+        [indNeighbors, nSites] = getNearestNeighbors(
+            latticeType=latticeType, latticeSize=self.latticeSize,
+            boundaryCondition=self.period_bnd_cond_x)
+        basisStatesUp = createHeisenbergfullBasis(nSites)
+        basisStatesDown = createHeisenbergfullBasis(nSites)
+        [nBasisStatesDown, dumpV] = np.shape(basisStatesDown)
+        [nBasisStatesUp, dumpV] = np.shape(basisStatesUp)
+        nHubbardStates = nBasisStatesDown * nBasisStatesUp
+        kVector = np.arange(start=0, stop=2*np.pi, step=2*np.pi/nSites)
+        [basisReprUp, symOpInvariantsUp, index2ReprUp, symOp2ReprUp
+         ] = findReprOnlyTrans(basisStatesUp, self.latticeSize, self.PP)
+        bin2dez = np.arange(nSites-1, -1, -1)
+        bin2dez = np.power(2, bin2dez)
+
+        intStatesDown = np.sum(basisStatesDown*bin2dez, axis=1)
+        intStatesUp = np.sum(basisStatesUp*bin2dez, axis=1)
+
+        kValue = kVector[kval]
+
+        [compDownStatesPerRepr, compInd2ReprDown, normHubbardStates
+         ] = combine2HubbardBasisOnlyTrans(
+         symOpInvariantsUp, basisStatesDown, self.latticeSize, kValue, self.PP,
+         Nmax=1)
+
+        H_down = calcHamiltonDownOnlyTrans(
+            compDownStatesPerRepr, compInd2ReprDown, self.paramT, indNeighbors,
+            normHubbardStates, symOpInvariantsUp, kValue, basisStatesDown,
+            self.latticeSize, self.PP)
+        H_up = calcHamiltonUpOnlyTrans(
+            basisReprUp, compDownStatesPerRepr, self.paramT, indNeighbors,
+            normHubbardStates, symOpInvariantsUp, kValue, index2ReprUp,
+            symOp2ReprUp, intStatesUp, self.latticeSize, self.PP)
+        H_diag = calcHubbardDiag(
+            basisReprUp, normHubbardStates, compDownStatesPerRepr, self.paramU)
+        H_diagN = Vterms_hamiltonDiagNumTrans(
+            basisReprUp, compDownStatesPerRepr, self.paramT, indNeighbors,
+            kValue, self.paramV, self.PP)
+
+        Hamk = H_diag + H_up + H_down + H_diagN
+        return [Qobj(Hamk), basisReprUp, compDownStatesPerRepr,
+                normHubbardStates]
+
+    def _Only_Nums_fermionic_Hubbard_chain(self, fillingUp, fillingDown):
+        """
+        Calculates the Hamiltonian in a basis with number symmetry specified.
+
+        fillingUp : int
+            The number of spin-up excitations in each basis member.
+        fillingDown : int
+            The number of spin-down excitations in each basis member.
+
+        Returns
+        -------
+        Qobj(Hamk) : Qobj(csr_matrix)
+            The Hamiltonian.
+        BasisStatesUp : numpy 2d array
+            The spin-up basis states.
+        BasisStatesDown : numpy 2d array
+            The spin-down basis states.
+        normHubbardStates : dict of 2d array of ints
+            The normalized basis states in which the Hamiltonian is formed.
+        """
+#        PP = -1
+        latticeType = 'cubic'
+        [indNeighbors, nSites] = getNearestNeighbors(
+            latticeType=latticeType, latticeSize=self.latticeSize,
+            boundaryCondition=self.period_bnd_cond_x)
+
+        nStatesUp = ncr(nSites, fillingUp)
+        nStatesDown = ncr(nSites, fillingDown)
+        [basisStatesUp, intStatesUp, indOnesUp
+         ] = createHeisenbergBasis(nStatesUp, nSites, fillingUp)
+        [basisStatesDown, integerBasisDown, indOnesDown
+         ] = createHeisenbergBasis(nStatesDown, nSites, fillingDown)
+
+        [nBasisStatesDown, dumpV] = np.shape(basisStatesDown)
+        [nBasisStatesUp, dumpV] = np.shape(basisStatesUp)
+
+        H_diag_NS = Uterms_hamiltonDiagNoSym(
+                basisStatesUp, basisStatesDown, self.paramU)
+        H_down_NS = HamiltonDownNoSym(
+                basisStatesDown, nBasisStatesUp, self.paramT, indNeighbors,
+                self.PP)
+        H_up_NS = hamiltonUpNoSyms(
+                basisStatesUp, basisStatesDown, self.paramT, indNeighbors,
+                self.PP)
+        H_diagN_NS = Vterms_hamiltonDiagNoSym(
+                basisStatesUp, basisStatesDown, self.paramT, indNeighbors,
+                self.paramV, self.PP)
+
+        H_NS = H_diag_NS + H_down_NS + H_up_NS + H_diagN_NS
+
+        normHubbardStates = np.ones((nStatesUp * nStatesDown), dtype=complex)
+        return [Qobj(H_NS), basisStatesUp, basisStatesDown, normHubbardStates]
+
+    def NoSym_DiagTrans(self):
+        """
+        Calculates the unitary transformation operator that block diagonalizes
+        the Hamiltonian with translational symmetry from the basis of no
+        symmmetry.
+
+        Returns
+        -------
+        Usss : Qobj()
+            The unitary operator
+        """
+        nSites = self.latticeSize[0]
+        basisStatesUp = createHeisenbergfullBasis(nSites)
+        basisStatesDown = createHeisenbergfullBasis(nSites)
+
+        Usss = UnitaryTrans(
+                self.latticeSize, basisStatesUp, basisStatesDown, PP=-1)
+        return Usss
+
+    def NoSym_DiagTrans_k(self, kval=0):
+        """
+        Calculates part of the unitary transformation operator that block
+        diagonalizes the Hamiltonian with translational symmetry at a specific
+        k-vector.
+
+        Returns
+        -------
+        Usss : Qobj()
+            The part of the unitary operator
+        """
+        nSites = self.latticeSize[0]
+        basisStatesUp = createHeisenbergfullBasis(nSites)
+        basisStatesDown = createHeisenbergfullBasis(nSites)
+
+        Usss_k = UnitaryTrans_k(
+                self.latticeSize, basisStatesUp, basisStatesDown, kval, PP=-1)
+        return Usss_k
+
+    def nums_DiagTrans(self, fillingUp=2, fillingDown=2):
+        """
+        Calculates the unitary transformation operator that block diagonalizes
+        the Hamiltonian with translational symmetry from the basis of number
+        specified symmetry.
+
+        Returns
+        -------
+        Usss : Qobj()
+            The unitary operator
+        """
+        nSites = self.latticeSize[0]
+        nStatesUp = ncr(nSites, fillingUp)
+        nStatesDown = ncr(nSites, fillingDown)
+        [basisStatesUp_n, intStatesUp, indOnesUp
+         ] = createHeisenbergBasis(nStatesUp, nSites, fillingUp)
+        [basisStatesDown_n, integerBasisDown, indOnesDown
+         ] = createHeisenbergBasis(nStatesDown, nSites, fillingDown)
+
+        Usss_n = UnitaryTrans(
+                self.latticeSize, basisStatesUp_n, basisStatesDown_n, PP=-1)
+        return Usss_n
+
+    def nums_DiagTrans_k(self, fillingUp=2, fillingDown=2, kval=0):
+        """
+        Calculates part of the unitary transformation operator that block
+        diagonalizes the Hamiltonian with translational symmetry at a specific
+        k-vector.
+
+        Returns
+        -------
+        Usss : Qobj()
+            The part of the unitary operator
+        """
+        nSites = self.latticeSize[0]
+        nStatesUp = ncr(nSites, fillingUp)
+        nStatesDown = ncr(nSites, fillingDown)
+        [basisStatesUp_n, intStatesUp, indOnesUp
+         ] = createHeisenbergBasis(nStatesUp, nSites, fillingUp)
+        [basisStatesDown_n, integerBasisDown, indOnesDown
+         ] = createHeisenbergBasis(nStatesDown, nSites, fillingDown)
+
+        Usss_nk = UnitaryTrans_k(
+            self.latticeSize, basisStatesUp_n, basisStatesDown_n, kval, PP=-1)
+        return Usss_nk
+
+
+class Lattice1d_fermions():
+    """A class for representing a 1d lattice with fermions hopping around in
+    the many particle physics picture.
+
+    The Lattice1d_fermions class can be defined with any specific unit cells
+    and a specified number of unit cells in the crystal.  It can return
+    Hamiltonians written in a chosen (with specific symmetry) basis and
+    unitary transformations that can be used in switching between them.
+
+    Parameters
+    ----------
+    num_sites : int
+        The number of sites in the fermi Hubbard lattice.
+    PP : int
+        The exchange phase factor for particles, -1 for fermions
+    boundary : str
+        Specification of the type of boundary the crystal is defined with.
+    t : float
+        The nearest neighbor hopping integral.
+
+    Attributes
+    ----------
+    num_sites : int
+        The number of sites in the fermi Hubbard lattice.
+    latticeType : str
+        A cubic lattice geometry isa ssumed.
+    period_bnd_cond_x : int
+        1 indicates "periodic" and 0 indicates "hardwall" boundary condition
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    """
+    def __init__(self, num_sites=10, boundary="periodic", t=1):
+        self.latticeType = 'cubic'
+        self.paramT = t
+        self.latticeSize = [num_sites]
+        self.PP = -1
+        if (not isinstance(num_sites, int)) or num_sites > 30:
+            raise Exception("cell_num_site is required to be a positive \
+                            integer.")
+        if boundary == "periodic":
+            self.period_bnd_cond_x = 1
+        elif boundary == "aperiodic" or boundary == "hardwall":
+            self.period_bnd_cond_x = 0
+        else:
+            raise Exception("Error in boundary: Only recognized bounday \
+                    options are:\"periodic \",\"aperiodic\" and \"hardwall\" ")
+
+    def __repr__(self):
+        s = ""
+        s += ("Lattice1d_f_HubbardN object: " +
+              "Number of sites = " + str(self.num_sites) +
+              ",\n hopping energy between sites, t = " + str(self.paramT) +
+              ",\n number of spin up fermions = " +
+              str(self.fillingUp) +
+              ",\n number of spin down fermions = " + str(self.fillingDown) +
+              ",\n k - vector sector = " + str(self.k) + "\n")
+        if self.period_bnd_cond_x == 1:
+            s += "Boundary Condition:  Periodic"
+        else:
+            s += "Boundary Condition:  Hardwall"
+        return s
+
+    def Hamiltonian(self, filling=None, kval=None):
+        """
+        Returns the Hamiltonian for the instance of Lattice1d_fermions.
+
+        filling : int
+            The number of excitations in each basis member.
+        kval : int
+            The index of reciprocal lattice vector specified for each basis
+            member.
+
+        Returns
+        ----------
+        Hamiltonian : qutip.Qobj
+            oper type Quantum object representing the lattice Hamiltonian.
+        basis : qutip.Oobj
+            The basis that the Hamiltonian is formed in.
+        """
+        if filling is None and kval is None:
+            Hamiltonian_list = spinlessFermions_NoSymHamiltonian(
+                self.paramT, self.latticeType, self.latticeSize, self.PP,
+                self.period_bnd_cond_x)
+        elif filling is not None and kval is None:
+            Hamiltonian_list = spinlessFermions_Only_nums(
+                self.paramT, self.latticeType, self.latticeSize, filling,
+                self.PP, self.period_bnd_cond_x)
+        elif filling is not None and kval is not None:
+            Hamiltonian_list = spinlessFermions_nums_Trans(
+                self.paramT, self.latticeType, self.latticeSize, filling, kval,
+                self.PP, self.period_bnd_cond_x)
+        elif filling is None and kval is not None:
+            Hamiltonian_list = spinlessFermions_OnlyTrans(
+                self.paramT, self.latticeType, self.latticeSize, kval, self.PP,
+                self.period_bnd_cond_x)
+
+        return Hamiltonian_list
+
+    def NoSym_DiagTrans(self):
+        """
+        Computes the unitary matrix that block-diagonalizes the Hamiltonian
+        written in a basis with k-vector symmetry.
+
+        Parameters
+        ==========
+        latticeSize : list of int
+            it has a single element as the number of cells as an integer.
+        basisStatesUp : 2d array of int
+            a 2d numpy array with each basis vector of spin-up's as a row
+        basisStatesDown : np.array of int
+            a 2d numpy array with each basis vector of spin-down's as a row
+        PP : int
+            The exchange phase factor for particles, +1 for bosons, -1 for
+            fermions
+
+        Returns
+        -------
+        Qobj(Usss) : Qobj(csr_matrix)
+            The unitary matrix that block-diagonalizes the Hamiltonian written
+            in a basis with k-vector symmetry.
+        """
+        PP = -1
+        latticeSize = self.latticeSize
+        nSites = latticeSize[0]
+        kVector = np.arange(start=0, stop=2*np.pi, step=2*np.pi/nSites)
+        symOpInvariantsUp = np.array([np.power(1, np.arange(nSites))])
+        basisStates_S = createHeisenbergfullBasis(latticeSize[0])
+        [nBasisStates, dumpV] = np.shape(basisStates_S)
+        bin2dez = np.arange(nSites-1, -1, -1)
+        bin2dez = np.power(2, bin2dez)
+        intDownStates = np.sum(basisStates_S*bin2dez, axis=1)
+
+        Is = 0
+        RowIndexUs = 0
+        sumL = 0
+        cumulIndex = np.zeros(nSites+1, dtype=int)
+        cumulIndex[0] = 0
+        # loop over k-vector
+        for ikVector in range(nSites):
+            kValue = kVector[ikVector]
+
+            [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+             ] = combine2HubbardBasisOnlyTrans(
+             symOpInvariantsUp, basisStates_S, latticeSize, kValue, PP, Nmax=1)
+            sumL = sumL + np.size(Ind2kDown[0])
+            cumulIndex[ikVector+1] = sumL
+            DownStatesPerk = DownStatesPerk[0]
+            [nReprUp, dumpV] = np.shape(DownStatesPerk)
+
+            for k in range(nReprUp):
+                DownState = DownStatesPerk[k, :]
+                DownState_int = np.sum(DownState * bin2dez, axis=0)
+                if DownState_int == intDownStates[0]:
+                    NewRI = k + RowIndexUs
+                    NewCI = 0
+                    NewEn = 1
+                    if Is == 0:
+                        UssRowIs = np.array([NewRI])
+                        UssColIs = np.array([NewCI])
+                        UssEntries = np.array([NewEn])
+                        Is = 1
+                    elif Is > 0:
+                        DLT = np.argwhere(UssRowIs == NewRI)
+                        iArg1 = DLT[:, 0]
+                        DLT = np.argwhere(UssColIs == NewCI)
+                        iArg2 = DLT[:, 0]
+                        if np.size(np.intersect1d(iArg1, iArg2)):
+                            AtR = np.intersect1d(iArg1, iArg2)
+                            UssEntries[AtR] = UssEntries[AtR] + NewEn
+                        else:
+                            Is = Is + 1
+                            UssRowIs = np.append(UssRowIs, np.array([NewRI]),
+                                                 axis=0)
+                            UssColIs = np.append(UssColIs, np.array([NewCI]),
+                                                 axis=0)
+                            UssEntries = np.append(UssEntries, np.array(
+                                [NewEn]), axis=0)
+
+                elif DownState_int == intDownStates[-1]:
+                    NewRI = k + RowIndexUs
+                    NewCI = np.power(2, nSites) - 1
+                    NewEn = 1
+
+                    if Is == 0:
+                        UssRowIs = np.array([NewRI])
+                        UssColIs = np.array([NewCI])
+                        UssEntries = np.array([NewEn])
+                        Is = 1
+                    elif Is > 0:
+                        DLT = np.argwhere(UssRowIs == NewRI)
+                        iArg1 = DLT[:, 0]
+                        DLT = np.argwhere(UssColIs == NewCI)
+                        iArg2 = DLT[:, 0]
+                        if np.size(np.intersect1d(iArg1, iArg2)):
+                            AtR = np.intersect1d(iArg1, iArg2)
+                            UssEntries[AtR] = UssEntries[AtR] + NewEn
+                        else:
+                            Is = Is + 1
+                            UssRowIs = np.append(UssRowIs, np.array([NewRI]),
+                                                 axis=0)
+                            UssColIs = np.append(UssColIs, np.array([NewCI]),
+                                                 axis=0)
+                            UssEntries = np.append(UssEntries, np.array(
+                                [NewEn]), axis=0)
+
+                else:
+                    # calculate period
+                    for h in range(1, nSites+1, 1):
+                        DownState_S = np.roll(DownState, -h)
+                        if (DownState_S == DownState).all():
+                            pn = h
+                            break
+
+                    no_of_flips = 0
+                    DownState_shifted = DownState
+
+                    for m in range(nSites):
+                        DownState_m = np.roll(DownState, -m)
+                        DownState_m_int = np.sum(DownState_m * bin2dez, axis=0)
+
+                        DLT = np.argwhere(intDownStates == DownState_m_int)
+                        ind_down = DLT[:, 0][0]
+
+                        if m > 0:
+                            DownState_shifted = np.roll(DownState_shifted, -1)
+                            if np.mod(np.count_nonzero(DownState) + 1, 2):
+                                no_of_flips = no_of_flips + DownState_shifted[
+                                    -1]
+                        else:
+                            no_of_flips = 0
+
+                        NewRI = k + RowIndexUs
+                        NewCI = ind_down
+                        NewEn = np.sqrt(pn) / nSites * np.power(
+                            PP, no_of_flips) * np.exp(
+                                -2 * np.pi * 1J / nSites * ikVector * m)
+                        if Is == 0:
+                            UssRowIs = np.array([NewRI])
+                            UssColIs = np.array([NewCI])
+                            UssEntries = np.array([NewEn])
+                            Is = 1
+                        elif Is > 0:
+                            DLT = np.argwhere(UssRowIs == NewRI)
+                            iArg1 = DLT[:, 0]
+                            DLT = np.argwhere(UssColIs == NewCI)
+                            iArg2 = DLT[:, 0]
+                            if np.size(np.intersect1d(iArg1, iArg2)):
+                                AtR = np.intersect1d(iArg1, iArg2)
+                                UssEntries[AtR] = UssEntries[AtR] + NewEn
+                            else:
+                                Is = Is + 1
+                                UssRowIs = np.append(
+                                    UssRowIs, np.array([NewRI]), axis=0)
+                                UssColIs = np.append(
+                                    UssColIs, np.array([NewCI]), axis=0)
+                                UssEntries = np.append(
+                                    UssEntries, np.array([NewEn]), axis=0)
+
+            RowIndexUs = RowIndexUs + cumulIndex[
+                ikVector+1] - cumulIndex[ikVector]
+        Usss = sparse.csr_matrix((UssEntries, (UssRowIs, UssColIs)),
+                                 shape=(nBasisStates, nBasisStates))
+        return Qobj(Usss)
+
+    def NoSym_DiagTrans_k(self, kval):
+        """
+        Computes the section of the unitary matrix that computes the
+        block-diagonalized Hamiltonian written in a basis with the given
+        k-vector symmetry.
+
+        Parameters
+        ==========
+        kval : int
+            The index of wave-vector which the basis members would have the
+            symmetry of.
+
+        Returns
+        -------
+        Qobj(Usss) : Qobj(csr_matrix)
+            The section of the unitary matrix that gives the Hamiltonian
+            written in a basis with k-vector symmetry.
+        """
+        latticeSize = self.latticeSize
+        PP = -1
+        nSites = latticeSize[0]
+        kVector = np.arange(start=0, stop=2*np.pi, step=2*np.pi/nSites)
+        symOpInvariantsUp = np.array([np.power(1, np.arange(nSites))])
+        basisStates_S = createHeisenbergfullBasis(latticeSize[0])
+        [nBasisStates, dumpV] = np.shape(basisStates_S)
+        bin2dez = np.arange(nSites - 1, -1, -1)
+        bin2dez = np.power(2, bin2dez)
+        intDownStates = np.sum(basisStates_S*bin2dez, axis=1)
+
+        Is = 0
+        RowIndexUs = 0
+        sumL = 0
+        cumulIndex = np.zeros(nSites+1, dtype=int)
+        cumulIndex[0] = 0
+        # loop over k-vector
+        for ikVector in range(kval, kval + 1, 1):
+            kValue = kVector[ikVector]
+
+            [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+             ] = combine2HubbardBasisOnlyTrans(
+             symOpInvariantsUp, basisStates_S, latticeSize, kValue, PP, Nmax=1)
+            sumL = sumL + np.size(Ind2kDown[0])
+            cumulIndex[ikVector+1] = sumL
+            #        print(cumulIndex)
+            DownStatesPerk = DownStatesPerk[0]
+            [nReprUp, dumpV] = np.shape(DownStatesPerk)
+
+            for k in range(nReprUp):
+                DownState = DownStatesPerk[k, :]
+                DownState_int = np.sum(DownState * bin2dez, axis=0)
+                if DownState_int == intDownStates[0]:
+                    NewRI = k + RowIndexUs
+                    NewCI = 0
+                    NewEn = 1
+                    if Is == 0:
+                        UssRowIs = np.array([NewRI])
+                        UssColIs = np.array([NewCI])
+                        UssEntries = np.array([NewEn])
+                        Is = 1
+                    elif Is > 0:
+                        DLT = np.argwhere(UssRowIs == NewRI)
+                        iArg1 = DLT[:, 0]
+                        DLT = np.argwhere(UssColIs == NewCI)
+                        iArg2 = DLT[:, 0]
+                        if np.size(np.intersect1d(iArg1, iArg2)):
+                            AtR = np.intersect1d(iArg1, iArg2)
+                            UssEntries[AtR] = UssEntries[AtR] + NewEn
+                        else:
+                            Is = Is + 1
+                            UssRowIs = np.append(UssRowIs, np.array([NewRI]),
+                                                 axis=0)
+                            UssColIs = np.append(UssColIs, np.array([NewCI]),
+                                                 axis=0)
+                            UssEntries = np.append(UssEntries, np.array(
+                                [NewEn]), axis=0)
+
+                elif DownState_int == intDownStates[-1]:
+                    NewRI = k + RowIndexUs
+                    NewCI = np.power(2, nSites) - 1
+                    NewEn = 1
+                    if Is == 0:
+                        UssRowIs = np.array([NewRI])
+                        UssColIs = np.array([NewCI])
+                        UssEntries = np.array([NewEn])
+                        Is = 1
+                    elif Is > 0:
+                        DLT = np.argwhere(UssRowIs == NewRI)
+                        iArg1 = DLT[:, 0]
+                        DLT = np.argwhere(UssColIs == NewCI)
+                        iArg2 = DLT[:, 0]
+                        if np.size(np.intersect1d(iArg1, iArg2)):
+                            AtR = np.intersect1d(iArg1, iArg2)
+                            UssEntries[AtR] = UssEntries[AtR] + NewEn
+                        else:
+                            Is = Is + 1
+                            UssRowIs = np.append(UssRowIs, np.array([NewRI]),
+                                                 axis=0)
+                            UssColIs = np.append(UssColIs, np.array([NewCI]),
+                                                 axis=0)
+                            UssEntries = np.append(UssEntries, np.array(
+                                [NewEn]), axis=0)
+                else:
+                    # calculate period
+                    for h in range(1, nSites+1, 1):
+                        DownState_S = np.roll(DownState, -h)
+                        if (DownState_S == DownState).all():
+                            pn = h
+                            break
+                    no_of_flips = 0
+                    DownState_shifted = DownState
+
+                    for m in range(nSites):
+                        DownState_m = np.roll(DownState, -m)
+                        DownState_m_int = np.sum(DownState_m * bin2dez, axis=0)
+
+                        DLT = np.argwhere(intDownStates == DownState_m_int)
+                        ind_down = DLT[:, 0][0]
+                        if m > 0:
+                            DownState_shifted = np.roll(DownState_shifted, -1)
+                            if np.mod(np.count_nonzero(DownState) + 1, 2):
+                                no_of_flips = no_of_flips + DownState_shifted[
+                                    -1]
+                        else:
+                            no_of_flips = 0
+
+                        NewRI = k + RowIndexUs
+                        NewCI = ind_down
+                        NewEn = np.sqrt(pn)/nSites * np.power(
+                            PP, no_of_flips) * np.exp(
+                                -2 * np.pi * 1J / nSites * ikVector * m)
+
+                        if Is == 0:
+                            UssRowIs = np.array([NewRI])
+                            UssColIs = np.array([NewCI])
+                            UssEntries = np.array([NewEn])
+                            Is = 1
+                        elif Is > 0:
+                            DLT = np.argwhere(UssRowIs == NewRI)
+                            iArg1 = DLT[:, 0]
+                            DLT = np.argwhere(UssColIs == NewCI)
+                            iArg2 = DLT[:, 0]
+                            if np.size(np.intersect1d(iArg1, iArg2)):
+                                AtR = np.intersect1d(iArg1, iArg2)
+                                UssEntries[AtR] = UssEntries[AtR] + NewEn
+                            else:
+                                Is = Is + 1
+                                UssRowIs = np.append(UssRowIs,
+                                                     np.array([NewRI]), axis=0)
+                                UssColIs = np.append(UssColIs,
+                                                     np.array([NewCI]), axis=0)
+                                UssEntries = np.append(
+                                    UssEntries, np.array([NewEn]), axis=0)
+
+            RowIndexUs = RowIndexUs + cumulIndex[
+                ikVector+1] - cumulIndex[ikVector]
+
+        Usss = sparse.csr_matrix((UssEntries, (UssRowIs, UssColIs)),
+                                 shape=(sumL, np.power(2, nSites)))
+        return Qobj(Usss)
+
+    def nums_DiagTrans(self, filling):
+        """
+        Computes the unitary matrix that block-diagonalizes the Hamiltonian
+        written in a basis without k-vector symmetry to with it.
+
+        Parameters
+        ==========
+        filling : int
+            The number of excitations in each basis member.
+
+        Returns
+        -------
+        Qobj(Usss) : Qobj(csr_matrix)
+            The unitary matrix that block-diagonalizes the Hamiltonian written
+            in a basis with k-vector symmetry.
+        """
+        latticeSize = self.latticeSize
+        PP = self.PP
+        nSites = latticeSize[0]
+        kVector = np.arange(start=0, stop=2*np.pi, step=2 * np.pi / nSites)
+
+        symOpInvariantsUp = np.array([np.power(1, np.arange(nSites))])
+        nStatesDown = ncr(nSites, filling)
+        [basisStates_S, integerBasisDown, indOnesDown
+         ] = createHeisenbergBasis(nStatesDown, nSites, filling)
+
+        [nBasisStates, dumpV] = np.shape(basisStates_S)
+        bin2dez = np.arange(nSites-1, -1, -1)
+        bin2dez = np.power(2, bin2dez)
+        intDownStates = np.sum(basisStates_S * bin2dez, axis=1)
+
+        Is = 0
+        RowIndexUs = 0
+        sumL = 0
+        cumulIndex = np.zeros(nSites+1, dtype=int)
+        cumulIndex[0] = 0
+        # loop over k-vector
+        for ikVector in range(nSites):
+            kValue = kVector[ikVector]
+
+            [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+             ] = combine2HubbardBasisOnlyTrans(
+             symOpInvariantsUp, basisStates_S, latticeSize, kValue, PP, Nmax=1)
+            sumL = sumL + np.size(Ind2kDown[0])
+            cumulIndex[ikVector + 1] = sumL
+            DownStatesPerk = DownStatesPerk[0]
+            [nReprUp, dumpV] = np.shape(DownStatesPerk)
+
+            for k in range(nReprUp):
+                DownState = DownStatesPerk[k, :]
+
+                # calculate period
+                for h in range(1, nSites + 1, 1):
+                    DownState_S = np.roll(DownState, -h)
+
+                    if (DownState_S == DownState).all():
+                        pn = h
+                        break
+
+                no_of_flips = 0
+                DownState_shifted = DownState
+                for m in range(nSites):
+                    DownState_m = np.roll(DownState, -m)
+                    DownState_m_int = np.sum(DownState_m * bin2dez, axis=0)
+
+                    DLT = np.argwhere(intDownStates == DownState_m_int)
+                    ind_down = DLT[:, 0][0]
+
+                    if m > 0:
+                        DownState_shifted = np.roll(DownState_shifted, -1)
+
+                        if np.mod(np.count_nonzero(DownState) + 1, 2):
+                            no_of_flips = no_of_flips + DownState_shifted[-1]
+                    else:
+                        no_of_flips = 0
+
+                    NewRI = k + RowIndexUs
+                    NewCI = ind_down
+                    NewEn = np.sqrt(pn)/nSites * np.power(
+                        PP, no_of_flips) * np.exp(
+                            -2 * np.pi * 1J / nSites * ikVector * m)
+
+                    if Is == 0:
+                        UssRowIs = np.array([NewRI])
+                        UssColIs = np.array([NewCI])
+                        UssEntries = np.array([NewEn])
+                        Is = 1
+                    elif Is > 0:
+                        DLT = np.argwhere(UssRowIs == NewRI)
+                        iArg1 = DLT[:, 0]
+                        DLT = np.argwhere(UssColIs == NewCI)
+                        iArg2 = DLT[:, 0]
+                        if np.size(np.intersect1d(iArg1, iArg2)):
+                            AtR = np.intersect1d(iArg1, iArg2)
+                            UssEntries[AtR] = UssEntries[AtR] + NewEn
+                        else:
+                            Is = Is + 1
+                            UssRowIs = np.append(UssRowIs, np.array(
+                                [NewRI]), axis=0)
+                            UssColIs = np.append(UssColIs, np.array(
+                                [NewCI]), axis=0)
+                            UssEntries = np.append(UssEntries, np.array(
+                                [NewEn]), axis=0)
+
+            RowIndexUs = RowIndexUs + cumulIndex[
+                ikVector+1] - cumulIndex[ikVector]
+
+        Usss = sparse.csr_matrix((UssEntries, (UssRowIs, UssColIs)),
+                                 shape=(nBasisStates, nBasisStates))
+
+        return Qobj(Usss)
+
+    def nums_DiagTrans_k(self, filling, kval):
+        """
+        Computes the section of the unitary matrix that computes the
+        block-diagonalized Hamiltonian written in a basis with the given
+        k-vector and number symmetry.
+
+        Parameters
+        ==========
+        filling : int
+            The specified number of excitations in each basis member.
+        kval : int
+            The index of wave-vector which the basis members would have the
+            symmetry of.
+
+        Returns
+        -------
+        Qobj(Usss) : Qobj(csr_matrix)
+            The section of the unitary matrix that gives the Hamiltonian
+            written in a basis with k-vector symmetry.
+        """
+        latticeSize = self.latticeSize
+        PP = self.PP
+        nSites = latticeSize[0]
+        kVector = np.arange(start=0, stop=2*np.pi, step=2*np.pi/nSites)
+
+        symOpInvariantsUp = np.array([np.power(1, np.arange(nSites))])
+        nStatesDown = ncr(nSites, filling)
+        [basisStates_S, integerBasisDown, indOnesDown
+         ] = createHeisenbergBasis(nStatesDown, nSites, filling)
+
+        [nBasisStates, dumpV] = np.shape(basisStates_S)
+        bin2dez = np.arange(nSites-1, -1, -1)
+        bin2dez = np.power(2, bin2dez)
+        intDownStates = np.sum(basisStates_S*bin2dez, axis=1)
+        Is = 0
+        sumL = 0
+        cumulIndex = np.zeros(nSites+1, dtype=int)
+        cumulIndex[0] = 0
+        for ikVector in range(latticeSize[0]):
+            kValue = kVector[kval]
+            [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+             ] = combine2HubbardBasisOnlyTrans(
+             symOpInvariantsUp, basisStates_S, latticeSize, kValue, PP, Nmax=1)
+            sumL = sumL + np.size(Ind2kDown[0])
+            cumulIndex[ikVector+1] = sumL
+        kValue = kVector[kval]
+        [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+         ] = combine2HubbardBasisOnlyTrans(
+         symOpInvariantsUp, basisStates_S, latticeSize, kValue, PP, Nmax=1)
+        DownStatesPerk = DownStatesPerk[0]
+        [nReprUp, dumpV] = np.shape(DownStatesPerk)
+        for k in range(nReprUp):
+            DownState = DownStatesPerk[k, :]
+            # calculate period
+            for h in range(1, nSites+1, 1):
+                DownState_S = np.roll(DownState, -h)
+                if (DownState_S == DownState).all():
+                    pn = h
+                    break
+            no_of_flips = 0
+            DownState_shifted = DownState
+            for m in range(nSites):
+                DownState_m = np.roll(DownState, -m)
+                DownState_m_int = np.sum(DownState_m * bin2dez, axis=0)
+                DLT = np.argwhere(intDownStates == DownState_m_int)
+                ind_down = DLT[:, 0][0]
+                if m > 0:
+                    DownState_shifted = np.roll(DownState_shifted, -1)
+                    if np.mod(np.count_nonzero(DownState) + 1, 2):
+                        no_of_flips = no_of_flips + DownState_shifted[-1]
+                else:
+                    no_of_flips = 0
+
+                NewRI = k
+                NewCI = ind_down
+                NewEn = np.sqrt(pn) / nSites * np.power(
+                    PP, no_of_flips) * np.exp(
+                        -2 * np.pi * 1J / nSites * kval * m)
+
+                if Is == 0:
+                    UssRowIs = np.array([NewRI])
+                    UssColIs = np.array([NewCI])
+                    UssEntries = np.array([NewEn])
+                    Is = 1
+                elif Is > 0:
+                    DLT = np.argwhere(UssRowIs == NewRI)
+                    iArg1 = DLT[:, 0]
+                    DLT = np.argwhere(UssColIs == NewCI)
+                    iArg2 = DLT[:, 0]
+                    if np.size(np.intersect1d(iArg1, iArg2)):
+                        AtR = np.intersect1d(iArg1, iArg2)
+                        UssEntries[AtR] = UssEntries[AtR] + NewEn
+                    else:
+                        Is = Is + 1
+                        UssRowIs = np.append(UssRowIs, np.array([NewRI]),
+                                             axis=0)
+                        UssColIs = np.append(UssColIs, np.array([NewCI]),
+                                             axis=0)
+                        UssEntries = np.append(UssEntries, np.array([NewEn]),
+                                               axis=0)
+
+        Usss = sparse.csr_matrix((UssEntries, (UssRowIs, UssColIs)),
+                                 shape=(cumulIndex[kval+1]-cumulIndex[kval],
+                                        nBasisStates))
+        return Qobj(Usss)

--- a/qutip_lattice/lattice_operators.py
+++ b/qutip_lattice/lattice_operators.py
@@ -1,0 +1,1118 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, The QuTiP Project.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+from scipy.sparse import (csr_matrix)
+import scipy.io as spio
+from qutip import (Qobj, tensor, basis, qeye, isherm, sigmax, sigmay, sigmaz,
+                   create, destroy)
+
+import numpy as np
+
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    pass
+
+
+from scipy import sparse
+from scipy.sparse.linalg import eigs
+import operator as op
+from functools import reduce
+import copy
+from numpy import asarray
+import math
+from .tran_sym_functions import *
+
+__all__ = ['n_i', 'ncr', 'Is', 'Sx', 'Sy', 'Sz', 'I', 'b_', 'bd', 'a_', 'ad',
+           'oprd', 'ncr', 'anticommutator', 'getNearestNeighbors',
+           'createHeisenbergBasis', 'calcHubbardDiag',
+           'Uterms_hamiltonDiagNoSym', 'n_i', 'Vterms_hamiltonDiagNoSym',
+           'HamiltonDownNoSym', 'hamiltonUpNoSyms',
+           'createHeisenbergfullBasis', 'createBosonBasis']
+
+
+def Is(i, levels=2):
+    """
+    Returns a list of identity operators of dimension levels.
+
+    Parameters
+    ==========
+    levels : int
+        the dimension of identity operators.
+
+    Returns
+    -------
+        a list of identity operators
+    """
+    return [qeye(levels) for j in range(0, i)]
+
+
+def Sx(N, i):
+    """
+    Returns the spin operator Sx.
+
+    Parameters
+    ==========
+    N : int
+        the dimension of space.
+
+    Returns
+    -------
+        operator Sx
+    """
+    return tensor(Is(i) + [sigmax()] + Is(N - i - 1))
+
+
+def Sy(N, i):
+    """
+    Returns the spin operator Sy.
+
+    Parameters
+    ==========
+    N : int
+        the dimension of space.
+
+    Returns
+    -------
+        operator Sy
+    """
+    return tensor(Is(i) + [sigmay()] + Is(N - i - 1))
+
+
+def Sz(N, i):
+    """
+    Returns the spin operator Sz.
+
+    Parameters
+    ==========
+    N : int
+        the dimension of space.
+
+    Returns
+    -------
+        operator Sx
+    """
+    return tensor(Is(i) + [sigmaz()] + Is(N - i - 1))
+
+
+def I(N):
+    """
+    An aide function.
+
+    Parameters
+    ==========
+    N : int
+        the dimension of space.
+
+    Returns
+    -------
+        aide operator I
+    """
+    return Sz(N, 0)*Sz(N, 0)
+
+
+def b_(N, Np, i):
+    """
+    Returns the bosonic annihilation operator at site N.
+
+    Parameters
+    ==========
+    Np : int
+        the dimension of Hilbert space per site.
+
+    Returns
+    -------
+        the annihilation operator
+    """
+    return tensor(
+            Is(i, levels=Np+1) + [destroy(Np+1)] + Is(N - i - 1, levels=Np+1))
+
+
+def bd(N, Np, i):
+    """
+    Returns the bosonic creation operator at site N.
+
+    Parameters
+    ==========
+    Np : int
+        the dimension of Hilbert space per site.
+
+    Returns
+    -------
+        the creation operator
+    """
+    return tensor(
+            Is(i, levels=Np+1) + [create(Np+1)] + Is(N - i - 1, levels=Np+1))
+
+
+def oprd(lst, d=None):
+    """
+    Returns the product of all elements of a list.
+
+    Returns
+    -------
+        the product
+    """
+    if len(lst) == 0:
+        return d
+    p = lst[0]
+    for U in lst[1:]:
+        p = p*U
+    return p
+
+
+def anticommutator(A, B):
+    """
+    Returns the quantum mechanical anticommutator.
+
+    Returns
+    -------
+        the anticommutator
+    """
+    return A*B + B*A
+
+
+def a_(N, n, Opers=None):
+    """
+    Returns the fermionic annihilation operator at site n.
+
+    Parameters
+    ==========
+    N : int
+        the length of lattice.
+
+    Returns
+    -------
+        the fermionic operator
+    """
+    Sa, Sb, Sc = Sz, Sx, Sy
+    if Opers is not None:
+        Sa, Sb, Sc = Opers
+    return oprd(
+            [Sa(N, j) for j in range(n)], d=I(N))*(Sb(N, n) + 1j*Sc(N, n))/2.
+
+
+def ad(N, n, Opers=None):
+    """
+    Returns the fermionic creation operator at site n.
+
+    Parameters
+    ==========
+    N : int
+        the length of lattice.
+
+    Returns
+    -------
+        the creation operator
+    """
+    Sa, Sb, Sc = Sz, Sx, Sy
+    if Opers is not None:
+        Sa, Sb, Sc = Opers
+    return oprd(
+            [Sa(N, j) for j in range(n)], d=I(N))*(Sb(N, n) - 1j*Sc(N, n))/2.
+
+
+def getNearestNeighbors(**kwargs):
+    """
+    Returns a list indicating nearest neighbors and an integer
+    storing the number of sites in the lattice.
+
+    Parameters
+    ==========
+    **kwargs : keyword arguments
+        kwargs["latticeSize"] provides the latticeSize list, which is has a
+        single element as the number of cells as an integer.
+        kwargs["boundaryCondition"] provides the boundary condition for the
+        lattice.
+
+    Returns
+    -------
+    indNeighbors : list of list of str
+        a list of indices that are the nearest neighbors of the indexed
+        lattice site
+    nSites : int
+        the number of sites in the lattice
+    """
+
+    latticeSize = kwargs["latticeSize"]
+
+    indNeighbors = np.arange(latticeSize[0]) + 1
+    indNeighbors = np.roll(indNeighbors, -1) - 1
+
+    nSites = latticeSize[0]
+
+    PBC_x = kwargs["boundaryCondition"]
+
+    if PBC_x == 0:
+        indNeighbors[nSites-1] = nSites - 1
+
+    return [indNeighbors, nSites]
+
+
+def ncr(n, r):
+    """
+    Combinations calculator.
+
+    Parameters
+    ==========
+    n : int
+        the number of objects to find combinations from
+    r : int
+        the number of objects in each combination
+
+    Returns
+    -------
+    numer // denom: int
+        the integer count of possible combinations
+    """
+    r = min(r, n-r)
+    numer = reduce(op.mul, range(n, n-r, -1), 1)
+    denom = reduce(op.mul, range(1, r+1), 1)
+    return numer // denom  # or / in Python 2
+
+
+def createHeisenbergBasis(nStates, nSites, S_ges):
+    """
+    creates the basis for the Hilbert space with a fixed number of particles.
+
+    Parameters
+    ==========
+    nStates : int
+        TThe number of states with the fixed number of excitations
+    nSites : int
+        The number of sites
+    S_ges : int
+        The difference between the number of sites and the number of
+        excitations
+
+    Returns
+    -------
+    basisStates : np.array
+        a 2d numpy array with each basis vector as a row
+    integerBasis : 1d array of int
+        array of integers that are decimal values for the each basis member
+        represented by a binary sequence
+    indOnes : 2d array of integers
+        Each row contains the indices of the basis vector where an excitation
+        is present
+    """
+    basisStates = np.zeros((nStates, nSites))
+
+    basisStates[0][nSites-S_ges: nSites] = 1
+
+    iSites = np.arange(1, nSites+1, 1)
+    indOnes = np.zeros((nStates, S_ges))
+
+    for iStates in range(0, nStates-1):
+        maskOnes = basisStates[iStates, :] == 1
+        indexOnes = iSites[maskOnes]
+        indOnes[iStates][:] = indexOnes
+        indexZeros = iSites[np.invert(maskOnes)]
+
+        rightMostZero = max(indexZeros[indexZeros < max(indexOnes)])-1
+        basisStates[iStates+1, :] = basisStates[iStates, :]
+        basisStates[iStates+1, rightMostZero] = 1
+        basisStates[iStates+1, rightMostZero+1:nSites] = 0
+
+        nDeletedOnes = sum(indexOnes > rightMostZero+1)
+        basisStates[iStates+1, nSites-nDeletedOnes+1:nSites] = 1
+
+    indOnes[nStates-1][:] = iSites[basisStates[nStates-1, :] == 1]
+
+    bi2de = np.arange(nSites-1, -1, -1)
+    bi2de = np.power(2, bi2de)
+
+    integerBasis = np.sum(basisStates * bi2de, axis=1)
+
+    return [basisStates, integerBasis, indOnes]
+
+
+def calcHubbardDiag(
+        basisReprUp, normHubbardStates, compDownStatesPerRepr, paramU):
+    """
+    calculates the diagonal elements of the Hubbard model
+
+    Parameters
+    ==========
+    basisReprUp : np.array of int
+        each row represents a basis in representation
+    normHubbardStates : dict of 1d array of floats
+        Normalized basis vectors for the Hubbard model
+    compDownStatesPerRepr : list of 2d array of int
+        array of basisstates for each representation
+    paramU : float
+        The Hubbard U parameter
+
+    Returns
+    -------
+    H_diag : csr_matrix
+        The diagonal matrix with the diagonal entries of the model's
+        Hamiltonian
+    """
+    [nReprUp, dumpV] = np.shape(basisReprUp)
+    nHubbardStates = 0
+    for k in range(nReprUp):
+        nHubbardStates = nHubbardStates + np.size(normHubbardStates[k])
+
+    # container for double occupancies
+    doubleOccupancies = {}
+    # loop over repr
+    for iRepr in range(nReprUp):
+        # pick out down states per up spin repr.
+        specBasisStatesDown = compDownStatesPerRepr[iRepr]
+        [nReprDown, dumpV] = np.shape(specBasisStatesDown)
+        UpReprs = [basisReprUp[iRepr, :]] * nReprDown
+        doubleOccupancies[iRepr] = np.sum(np.logical_and(
+            UpReprs, compDownStatesPerRepr[iRepr]), axis=1)
+        if iRepr == 0:
+            doubleOccupanciesA = doubleOccupancies[iRepr]
+        elif iRepr > 0:
+            doubleOccupanciesA = np.concatenate((doubleOccupanciesA,
+                                                 doubleOccupancies[iRepr]))
+    rowIs = np.arange(0, nHubbardStates, 1)
+    H_diag = sparse.csr_matrix((paramU * doubleOccupanciesA, (rowIs, rowIs)),
+                               shape=(nHubbardStates, nHubbardStates))
+    return H_diag
+
+
+def Uterms_hamiltonDiagNoSym(basisStatesUp, basisStatesDown, paramU):
+    """
+    For the Hilbert space with the full basis(not restricted to some symmetry),
+    computes the diagonal Hamiltonian holding the terms due to onsite
+    interaction U.
+
+    Parameters
+    ==========
+    basisStatesUp : 2d array of int
+        a 2d numpy array with each basis vector of spin-up's as a row
+    basisStatesDown : np.array of int
+        a 2d numpy array with each basis vector of spin-down's as a row
+    paramU : float
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+
+    Returns
+    -------
+    H_diag : csr_matrix
+        The diagonal matrix with the diagonal entries of the model's
+        Hamiltonian
+    """
+    [nBasisStatesUp, dumpV] = np.shape(basisStatesUp)
+    [nBasisStatesDown, dumpV] = np.shape(basisStatesDown)
+    nHubbardStates = nBasisStatesUp * nBasisStatesDown
+    # container for double occupancies
+    doubleOccupancies = {}
+    # loop over repr
+    for iRepr in range(nBasisStatesUp):
+        UpBasis = [basisStatesUp[iRepr, :]] * nBasisStatesDown
+        doubleOccupancies[iRepr] = np.sum(np.logical_and(
+            UpBasis, basisStatesDown), axis=1)
+        if iRepr == 0:
+            doubleOccupanciesA = doubleOccupancies[iRepr]
+        elif iRepr > 0:
+            doubleOccupanciesA = np.concatenate((
+                doubleOccupanciesA, doubleOccupancies[iRepr]))
+    rowIs = np.arange(0, nHubbardStates, 1)
+    H_diag = sparse.csr_matrix((paramU * doubleOccupanciesA, (rowIs, rowIs)),
+                               shape=(nHubbardStates, nHubbardStates))
+
+    return H_diag
+
+
+def Vterms_hamiltonDiagNoSym(
+        basisStatesUp, basisStatesDown, paramT, indNeighbors, paramV, PP):
+    """
+    For the Hilbert space with the full basis(not restricted to some symmetry),
+    computes the diagonal Hamiltonian holding the terms due to the nearest
+    neighbor interaction V.
+
+    Parameters
+    ==========
+    basisStatesUp : 2d array of int
+        a 2d numpy array with each basis vector of spin-up's as a row
+    basisStatesDown : np.array of int
+        a 2d numpy array with each basis vector of spin-down's as a row
+    paramT : float
+        The nearest neighbor hopping integral
+    indNeighbors : list of list of str
+        a list of indices that are the nearest neighbors of the indexed
+        lattice site
+    paramV : float
+        The V parameter in the extended Hubbard model
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+
+    Returns
+    -------
+    HdiagV : csr_matrix
+        The diagonal matrix with the diagonal entries due to the V interaction
+        of the extended Hubbard model.
+
+    """
+    [nReprUp, nSites] = np.shape(basisStatesUp)
+
+    xFinal = {}
+    yFinal = {}
+    HVelem = {}
+    cumulIndex = np.zeros(nReprUp + 1, dtype=int)
+    cumulIndex[0] = 0
+    sumL = 0
+    for iReprUp in range(nReprUp):
+        sumL = sumL + np.shape(basisStatesDown)[0]
+        cumulIndex[iReprUp+1] = sumL
+        basisStateUp = basisStatesUp[iReprUp]
+
+        # Up Spin- Up Spin
+        B2 = basisStateUp[indNeighbors]
+        B2 = np.logical_xor(basisStateUp, B2)
+        TwoA = np.argwhere(B2)
+        USp = (2 * np.count_nonzero(basisStateUp) - len(TwoA))/2
+
+        [nBasisStatesDown, dumpV] = np.shape(basisStatesDown)
+
+        xFinal[iReprUp] = cumulIndex[iReprUp] + np.arange(nBasisStatesDown)
+        yFinal[iReprUp] = cumulIndex[iReprUp] + np.arange(nBasisStatesDown)
+
+        HVelem[iReprUp] = USp * paramV * np.ones(nBasisStatesDown)
+
+        # Down Spin- Down Spin
+        B2 = basisStatesDown[:, indNeighbors]
+        B2 = np.logical_xor(basisStatesDown, B2)
+        HVelem[iReprUp] = HVelem[iReprUp] + paramV * (2*np.count_nonzero(
+            basisStatesDown, 1) - np.count_nonzero(B2, 1))/2
+        # Up Spin- Down Spin
+        B2 = basisStatesDown[:, indNeighbors]
+        B2 = np.logical_xor(basisStateUp, B2)
+
+        HVelem[iReprUp] = HVelem[iReprUp] + 2 * paramV * (2 * np.count_nonzero(
+            basisStatesDown, 1) - np.count_nonzero(B2, 1)) / 2
+
+    xFinalA = np.zeros(cumulIndex[-1], dtype=int)
+    yFinalA = np.zeros(cumulIndex[-1], dtype=int)
+    HVelemA = np.zeros(cumulIndex[-1], dtype=complex)
+
+    for iReprUp in range(nReprUp):
+        xFinalA[cumulIndex[iReprUp]:cumulIndex[iReprUp + 1]] = xFinal[iReprUp]
+        yFinalA[cumulIndex[iReprUp]:cumulIndex[iReprUp + 1]] = yFinal[iReprUp]
+        HVelemA[cumulIndex[iReprUp]:cumulIndex[iReprUp + 1]] = HVelem[iReprUp]
+
+    FinL = np.shape(xFinalA)[0]
+    for ii in range(FinL):
+        for jj in range(ii + 1, FinL, 1):
+
+            if xFinalA[ii] == xFinalA[jj] and yFinalA[ii] == yFinalA[jj]:
+                HVelemA[ii] = HVelemA[ii] + HVelemA[jj]
+
+                HVelemA[jj] = 0
+                xFinalA[jj] = cumulIndex[-1] - 1
+                yFinalA[jj] = cumulIndex[-1] - 1
+
+    HdiagV = sparse.csr_matrix((HVelemA, (xFinalA, yFinalA)),
+                               shape=(cumulIndex[-1], cumulIndex[-1]))
+
+    return (HdiagV + HdiagV.transpose().conjugate())/2
+
+
+def HamiltonDownNoSym(
+        basisStatesDown, nBasisStatesUp, paramT, indNeighbors, PP):
+    """
+    For the Hilbert space with the basis with a specific k-symmetry,
+    computes the Hamiltonian elements holding the terms due to nearest neighbor
+    hopping between down spin parts of the basis.
+
+    Parameters
+    ==========
+    basisStatesDown : np.array of int
+        a 2d numpy array with each basis vector as a row
+    nBasisStatesUp : int
+        number of basis members in the up-spin basis with no symmetry
+    paramT : float
+        The nearest neighbor hopping integral
+    indNeighbors : list of list of str
+        a list of indices that are the nearest neighbors of the indexed
+        lattice site
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+
+    Returns
+    -------
+    H_down : csr_matrix
+        The matrix elements that are associated with hopping between spin-down
+        parts of the chosen basis.
+
+    """
+    [nBasisStatesDown, nSites] = np.shape(basisStatesDown)
+    bin2dez = np.arange(nSites-1, -1, -1)
+    bin2dez = np.power(2, bin2dez)
+
+    # number of dimensions of lattice:
+    [nDims, ] = np.shape(indNeighbors)
+    # number of basis states of whole down spin basis
+
+    B2 = basisStatesDown[:, indNeighbors]
+    B2 = np.logical_xor(basisStatesDown, B2)
+    TwoA = np.argwhere(B2)
+    xIndHubbard = TwoA[:, 0]
+    d = TwoA[:, 1]
+    f = indNeighbors[d]
+    f1 = np.append(d, f, axis=0)
+    d1 = np.append(np.arange(np.count_nonzero(B2)), np.arange(
+        np.count_nonzero(B2)), axis=0)
+    F_i = basisStatesDown[np.sum(B2, axis=1) == 0, :]
+    F = np.sum(F_i*bin2dez, axis=1)
+
+    B2 = basisStatesDown[xIndHubbard, :]
+    d1 = sparse.csr_matrix((np.ones(np.size(d1)), (d1, f1)), shape=(np.max(
+        d1) + 1, nSites))
+
+    phasesHubbard = HubbardPhase(B2, d1, d, f, PP)
+    d = np.logical_xor(d1.todense(), B2)
+    prodd = d * np.reshape(bin2dez, (nSites, 1))
+    d = np.sum(prodd, axis=1)
+    d = np.squeeze(np.asarray(d))
+
+    f = np.append(d, F, axis=0)
+    [uniqueInteger, indUniqueInteger, B2] = np.unique(f, return_index=True,
+                                                      return_inverse=True)
+
+    yIndHubbard = B2[np.arange(0, np.size(xIndHubbard), 1)]
+    sums = 0
+    cumulIndFinal = np.zeros(nBasisStatesUp * nBasisStatesDown, dtype=int)
+    cumulIndFinal[0] = sums
+
+    nIndH = np.size(xIndHubbard)
+
+    nHubbardStates = nBasisStatesUp * nBasisStatesDown
+    xIndA = np.zeros(nIndH * nBasisStatesDown, dtype=int)
+    yIndA = np.zeros(nIndH * nBasisStatesDown, dtype=int)
+    phaseFactorA = np.zeros(nIndH * nBasisStatesDown, dtype=complex)
+
+    for iBasisUp in range(nBasisStatesUp):
+        xIndA[iBasisUp * nIndH:(iBasisUp + 1) * nIndH
+              ] = xIndHubbard + iBasisUp * nBasisStatesDown
+        yIndA[iBasisUp * nIndH:(iBasisUp + 1) * nIndH
+              ] = yIndHubbard + iBasisUp * nBasisStatesDown
+        phaseFactorA[iBasisUp * nIndH:(iBasisUp + 1) * nIndH] = phasesHubbard
+
+    H_down_elems = -paramT * phaseFactorA
+    H_down = sparse.csr_matrix((H_down_elems, (xIndA, yIndA)),
+                               shape=(nHubbardStates, nHubbardStates))
+
+    return (H_down + H_down.transpose().conjugate())/2
+
+
+def hamiltonUpNoSyms(basisStatesUp, basisStatesDown, paramT, indNeighbors, PP):
+    """
+    For the Hilbert space with the basis with a specific k-symmetry,
+    computes the Hamiltonian elements holding the terms due to nearest neighbor
+    hopping between down spin parts of the basis.
+
+    Parameters
+    ==========
+    basisStatesUp : np.array of int
+        a 2d numpy array with each basis vector as a row
+    nBasisStatesDown : int
+        number of basis members in the down-spin basis with no symmetry
+    paramT : float
+        The nearest neighbor hopping integral
+    indNeighbors : list of list of str
+        a list of indices that are the nearest neighbors of the indexed
+        lattice site
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+
+    Returns
+    -------
+    H_up : csr_matrix
+        The matrix elements that are associated with hopping between spin-up
+        parts of the chosen basis.
+
+    """
+    [nBasisStatesUp, nSites] = np.shape(basisStatesUp)
+    [nBasisStatesDown, dumpV] = np.shape(basisStatesDown)
+
+    nHubbardStates = nBasisStatesUp * nBasisStatesDown
+    bi2de = np.arange(nSites - 1, -1, -1)
+    bi2de = np.power(2, bi2de)
+
+    intStatesUp = np.sum(basisStatesUp * bi2de, axis=1)
+
+    B2 = basisStatesUp[:, indNeighbors]
+    B2 = np.logical_xor(basisStatesUp, B2)
+    TwoA = np.argwhere(B2)
+    xIndHubbard = TwoA[:, 0]
+    d = TwoA[:, 1]
+    f = indNeighbors[d]
+    f1 = np.append(d, f, axis=0)
+    d1 = np.append(np.arange(np.count_nonzero(B2)), np.arange(np.count_nonzero(
+        B2)), axis=0)
+    F_i = basisStatesUp[np.sum(B2, axis=1) == 0, :]
+    F = np.sum(F_i*bi2de, axis=1)
+    B2 = basisStatesUp[xIndHubbard, :]
+    d1 = sparse.csr_matrix((np.ones(np.size(d1)), (d1, f1)), shape=(
+        np.max(d1) + 1, nSites))
+    phasesHubbard = HubbardPhase(B2, d1, d, f, PP)
+    d = np.logical_xor(d1.todense(), B2)
+    prodd = d * np.reshape(bi2de, (nSites, 1))
+    d = np.sum(prodd, axis=1)
+    d = np.squeeze(np.asarray(d))
+    f = np.append(d, F, axis=0)
+    F = np.setdiff1d(intStatesUp, f)
+    f = np.append(f, F)
+    [uniqueInteger, indUniqueInteger, B2] = np.unique(f, return_index=True,
+                                                      return_inverse=True)
+
+    yIndHubbard = B2[np.arange(0, np.size(xIndHubbard), 1)]
+    indBasis = np.arange(1, nBasisStatesDown + 1, 1)
+    sums = 0
+    cumulIndFinal = np.zeros(nBasisStatesUp * nBasisStatesDown, dtype=int)
+    cumulIndFinal[0] = sums
+
+    nIndH = np.size(xIndHubbard)
+    xIndA = np.zeros(nIndH * nBasisStatesDown, dtype=int)
+    yIndA = np.zeros(nIndH * nBasisStatesDown, dtype=int)
+    phaseFactorA = np.zeros(nIndH * nBasisStatesDown, dtype=complex)
+
+    for inH in range(nIndH):
+        xIndA[inH*nBasisStatesDown:(inH + 1) * nBasisStatesDown
+              ] = xIndHubbard[inH] * nBasisStatesDown + indBasis - 1
+        yIndA[inH*nBasisStatesDown:(inH + 1) * nBasisStatesDown
+              ] = yIndHubbard[inH] * nBasisStatesDown + indBasis - 1
+        phaseFactorA[inH*nBasisStatesDown:(inH + 1) * nBasisStatesDown
+                     ] = phasesHubbard[inH]
+
+    H_up_elems = -paramT * phaseFactorA
+    H_up = sparse.csr_matrix((H_up_elems, (xIndA, yIndA)), shape=(
+        nHubbardStates, nHubbardStates))
+
+    return (H_up + H_up.transpose().conjugate())/2
+
+
+def UnitaryTrans(latticeSize, basisStatesUp, basisStatesDown, PP):
+    """
+    Computes the unitary matrix that block-diagonalizes the Hamiltonian written
+    in a basis with k-vector symmetry.
+
+    Parameters
+    ==========
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    basisStatesUp : 2d array of int
+        a 2d numpy array with each basis vector of spin-up's as a row
+    basisStatesDown : np.array of int
+        a 2d numpy array with each basis vector of spin-down's as a row
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+
+    Returns
+    -------
+    Qobj(Usss) : Qobj(csr_matrix)
+        The unitary matrix that block-diagonalizes the Hamiltonian written in
+        a basis with k-vector symmetry.
+    """
+    [nBasisStatesUp, nSites] = np.shape(basisStatesUp)
+    [nBasisStatesDown, dumpV] = np.shape(basisStatesDown)
+
+    [basisReprUp, symOpInvariantsUp, index2ReprUp, symOp2ReprUp
+     ] = findReprOnlyTrans(basisStatesUp, latticeSize, PP)
+
+    bin2dez = np.arange(nSites-1, -1, -1)
+    bin2dez = np.power(2, bin2dez)
+    intDownStates = np.sum(basisStatesDown * bin2dez, axis=1)
+    intUpStates = np.sum(basisStatesUp * bin2dez, axis=1)
+    kVector = np.arange(start=0, stop=2 * np.pi,
+                        step=2 * np.pi / latticeSize[0])
+
+    Is = 0
+    RowIndexUs = 0
+    # loop over k-vector
+    for ikVector in range(latticeSize[0]):
+        kValue = kVector[ikVector]
+
+        [compDownStatesPerRepr, compInd2ReprDown, normHubbardStates
+         ] = combine2HubbardBasisOnlyTrans(
+         symOpInvariantsUp, basisStatesDown, latticeSize, kValue, PP, Nmax=1)
+        [nReprUp, nSites] = np.shape(basisReprUp)
+        cumulIndex = np.zeros(nReprUp+1, dtype=int)
+        cumulIndex[0] = 0
+        sumL = 0
+        for iReprUp in range(nReprUp):
+            rt = symOpInvariantsUp[iReprUp, :]
+            rt = rt[rt == 1]
+            sumL = sumL + np.size(normHubbardStates[iReprUp])
+            cumulIndex[iReprUp+1] = sumL
+        for k in range(nReprUp):
+            UpState = basisReprUp[k, :]
+            basisStatesDown_k = compDownStatesPerRepr[k]
+            fillingUp = np.count_nonzero(UpState)
+
+            for l in range(cumulIndex[k], cumulIndex[k + 1], 1):
+                DownState = basisStatesDown_k[l - cumulIndex[k], :]
+                fillingDown = np.count_nonzero(DownState)
+
+                # calculate period
+                for h in range(1, nSites + 1, 1):
+                    DownState_S = np.roll(DownState, -h)
+                    UpState_S = np.roll(UpState, -h)
+
+                    if ((DownState_S == DownState).all() and (
+                            UpState_S == UpState).all()):
+                        pn = h
+                        break
+                no_of_flips = 0
+                DownState_shifted = DownState
+                UpState_shifted = UpState
+
+                for m in range(nSites):
+                    DownState_m = np.roll(DownState, -m)
+                    DownState_m_int = np.sum(DownState_m * bin2dez, axis=0)
+
+                    UpState_m = np.roll(UpState, -m)
+                    UpState_m_int = np.sum(UpState_m * bin2dez, axis=0)
+
+                    DLT = np.argwhere(intDownStates == DownState_m_int)
+                    ind_down = DLT[:, 0][0]
+                    DLT = np.argwhere(intUpStates == UpState_m_int)
+                    ind_up = DLT[:, 0][0]
+
+                    if m > 0:
+                        DownState_shifted = np.roll(DownState_shifted, -1)
+                        UpState_shifted = np.roll(UpState_shifted, -1)
+
+                        if np.mod(fillingUp + 1, 2):
+                            no_of_flips = no_of_flips + UpState_shifted[-1]
+
+                        if np.mod(fillingDown + 1, 2):
+                            no_of_flips = no_of_flips + DownState_shifted[-1]
+
+                    else:
+                        no_of_flips = 0
+
+                    NewRI = l + RowIndexUs
+                    NewCI = ind_up * nBasisStatesDown + ind_down
+
+                    NewEn = np.sqrt(pn) / nSites * np.power(
+                        PP, no_of_flips) * np.exp(
+                            -2 * np.pi * 1J / nSites * ikVector * m)
+
+                    if Is == 0:
+                        UssRowIs = np.array([NewRI])
+                        UssColIs = np.array([NewCI])
+                        UssEntries = np.array([NewEn])
+                        Is = 1
+                    elif Is > 0:
+                        DLT = np.argwhere(UssRowIs == NewRI)
+                        iArg1 = DLT[:, 0]
+                        DLT = np.argwhere(UssColIs == NewCI)
+                        iArg2 = DLT[:, 0]
+                        if np.size(np.intersect1d(iArg1, iArg2)):
+                            AtR = np.intersect1d(iArg1, iArg2)
+                            UssEntries[AtR] = UssEntries[AtR] + NewEn
+                        else:
+                            Is = Is + 1
+                            UssRowIs = np.append(UssRowIs, np.array([NewRI]),
+                                                 axis=0)
+                            UssColIs = np.append(UssColIs, np.array([NewCI]),
+                                                 axis=0)
+                            UssEntries = np.append(UssEntries, np.array(
+                                [NewEn]), axis=0)
+        RowIndexUs = RowIndexUs + cumulIndex[-1]
+    Usss = sparse.csr_matrix((UssEntries, (UssRowIs, UssColIs)), shape=(
+        nBasisStatesUp * nBasisStatesDown, nBasisStatesUp * nBasisStatesDown))
+    return Qobj(Usss)
+
+
+def UnitaryTrans_k(latticeSize, basisStatesUp, basisStatesDown, kval, PP):
+    """
+    Computes the section of the unitary matrix that computes the
+    block-diagonalized Hamiltonian written in a basis with the given k-vector
+    symmetry.
+
+    Parameters
+    ==========
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    basisStatesUp : 2d array of int
+        a 2d numpy array with each basis vector of spin-up's as a row
+    basisStatesDown : np.array of int
+        a 2d numpy array with each basis vector of spin-down's as a row
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+
+    Returns
+    -------
+    Qobj(Usss) : Qobj(csr_matrix)
+        The section of the unitary matrix that gives the Hamiltonian written in
+        a basis with k-vector symmetry.
+    """
+    [nBasisStatesUp, nSites] = np.shape(basisStatesUp)
+    [nBasisStatesDown, dumpV] = np.shape(basisStatesDown)
+
+    [basisReprUp, symOpInvariantsUp, index2ReprUp, symOp2ReprUp
+     ] = findReprOnlyTrans(basisStatesUp, latticeSize, PP)
+
+    bin2dez = np.arange(nSites-1, -1, -1)
+    bin2dez = np.power(2, bin2dez)
+    intDownStates = np.sum(basisStatesDown * bin2dez, axis=1)
+    intUpStates = np.sum(basisStatesUp*bin2dez, axis=1)
+    kVector = np.arange(start=0, stop=2 * np.pi,
+                        step=2 * np.pi / latticeSize[0])
+
+    Is = 0
+    RowIndexUs = 0
+    for ikVector in np.arange(kval, kval + 1, 1):
+        kValue = kVector[ikVector]
+
+        [compDownStatesPerRepr, compInd2ReprDown, normHubbardStates
+         ] = combine2HubbardBasisOnlyTrans(
+         symOpInvariantsUp, basisStatesDown, latticeSize, kValue, PP, Nmax=1)
+        [nReprUp, nSites] = np.shape(basisReprUp)
+        cumulIndex = np.zeros(nReprUp+1, dtype=int)
+        cumulIndex[0] = 0
+        sumL = 0
+        for iReprUp in range(nReprUp):
+            rt = symOpInvariantsUp[iReprUp, :]
+            rt = rt[rt == 1]
+            sumL = sumL + np.size(normHubbardStates[iReprUp])
+            cumulIndex[iReprUp+1] = sumL
+
+        for k in range(nReprUp):
+            UpState = basisReprUp[k, :]
+            basisStatesDown_k = compDownStatesPerRepr[k]
+
+            fillingUp = np.count_nonzero(UpState)
+
+            for l in range(cumulIndex[k], cumulIndex[k + 1], 1):
+                DownState = basisStatesDown_k[l-cumulIndex[k], :]
+                fillingDown = np.count_nonzero(DownState)
+
+                # calculate period
+                for h in range(1, nSites+1, 1):
+                    DownState_S = np.roll(DownState, -h)
+                    UpState_S = np.roll(UpState, -h)
+
+                    if ((DownState_S == DownState).all() and (
+                            UpState_S == UpState).all()):
+                        pn = h
+                        break
+                no_of_flips = 0
+                DownState_shifted = DownState
+                UpState_shifted = UpState
+
+                for m in range(nSites):
+                    DownState_m = np.roll(DownState, -m)
+                    DownState_m_int = np.sum(DownState_m * bin2dez, axis=0)
+
+                    UpState_m = np.roll(UpState, -m)
+                    UpState_m_int = np.sum(UpState_m * bin2dez, axis=0)
+
+                    DLT = np.argwhere(intDownStates == DownState_m_int)
+                    ind_down = DLT[:, 0][0]
+                    DLT = np.argwhere(intUpStates == UpState_m_int)
+                    ind_up = DLT[:, 0][0]
+
+                    if m > 0:
+                        DownState_shifted = np.roll(DownState_shifted, -1)
+                        UpState_shifted = np.roll(UpState_shifted, -1)
+
+                        if np.mod(fillingUp + 1, 2):
+                            no_of_flips = no_of_flips + UpState_shifted[-1]
+
+                        if np.mod(fillingDown + 1, 2):
+                            no_of_flips = no_of_flips + DownState_shifted[-1]
+                    else:
+                        no_of_flips = 0
+
+                    NewRI = l + 0 * RowIndexUs
+                    NewCI = ind_up * nBasisStatesDown + ind_down
+                    NewEn = np.sqrt(pn) / nSites * np.power(
+                        PP, no_of_flips) * np.exp(
+                            -2 * np.pi * 1J / nSites * ikVector * m)
+
+                    if Is == 0:
+                        UssRowIs = np.array([NewRI])
+                        UssColIs = np.array([NewCI])
+                        UssEntries = np.array([NewEn])
+                        Is = 1
+                    elif Is > 0:
+                        DLT = np.argwhere(UssRowIs == NewRI)
+                        iArg1 = DLT[:, 0]
+                        DLT = np.argwhere(UssColIs == NewCI)
+                        iArg2 = DLT[:, 0]
+                        if np.size(np.intersect1d(iArg1, iArg2)):
+                            AtR = np.intersect1d(iArg1, iArg2)
+                            UssEntries[AtR] = UssEntries[AtR] + NewEn
+                        else:
+                            Is = Is + 1
+                            UssRowIs = np.append(UssRowIs, np.array([NewRI]),
+                                                 axis=0)
+                            UssColIs = np.append(UssColIs, np.array([NewCI]),
+                                                 axis=0)
+                            UssEntries = np.append(UssEntries, np.array(
+                                [NewEn]), axis=0)
+        RowIndexUs = RowIndexUs + cumulIndex[-1]
+
+    Usss = sparse.csr_matrix((UssEntries, (UssRowIs, UssColIs)), shape=(
+        cumulIndex[-1], nBasisStatesUp * nBasisStatesDown))
+    return Qobj(Usss)
+
+
+def n_i(i, basisStatesUp, basisStatesDown):
+    """
+    Computes the particle density operator at site i.
+
+    Parameters
+    ==========
+    basisStatesUp : 2d array of int
+        a 2d numpy array with each basis vector of spin-up's as a row
+    basisStatesDown : np.array of int
+        a 2d numpy array with each basis vector of spin-down's as a row
+
+    Returns
+    -------
+    uni : Qobj
+        the up-spin fermion density operator at site i.
+    dni : Qobj
+        the down-spin fermion density operator at site i.
+    """
+    [nBasisStatesUp, nSites] = np.shape(basisStatesUp)
+    [nBasisStatesDown, dumpV] = np.shape(basisStatesDown)
+    nHubbardStates = nBasisStatesUp * nBasisStatesDown
+
+    i_only = np.zeros(nSites)
+    i_only[i] = 1
+    uIs = 0
+    dIs = 0
+
+    for j in range(nHubbardStates):
+        k = int(j/nBasisStatesDown)
+        if (np.logical_and(i_only, basisStatesUp[k, :])).any():
+            if uIs == 0:
+                uRowIs = np.array([j])
+                uEntries = np.array([1])
+                uIs = 1
+            else:
+                uIs = uIs + 1
+                uRowIs = np.append(uRowIs, np.array([j]), axis=0)
+                uEntries = np.append(uEntries, np.array([1]), axis=0)
+
+        k = np.mod(j, nBasisStatesDown)
+        if (np.logical_and(i_only, basisStatesDown[k, :])).any():
+            if dIs == 0:
+                dRowIs = np.array([j])
+                dEntries = np.array([1])
+                dIs = 1
+            else:
+                dIs = dIs + 1
+                dRowIs = np.append(dRowIs, np.array([j]), axis=0)
+                dEntries = np.append(dEntries, np.array([1]), axis=0)
+
+    uni = sparse.csr_matrix(
+        (uEntries, (uRowIs, uRowIs)), shape=(nHubbardStates, nHubbardStates))
+    dni = sparse.csr_matrix(
+        (dEntries, (dRowIs, dRowIs)), shape=(nHubbardStates, nHubbardStates))
+
+    return [uni, dni]
+
+
+def createHeisenbergfullBasis(nSites):
+    """
+    Computes the basis with no symmetry specified for the Fermionic Hubbard
+    model.
+
+    Parameters
+    ==========
+    nSites : int
+        The number of sites in the lattice
+
+    Returns
+    -------
+    fullBasis : numpy 2d array
+        Each row records a basis member of the full-basis.
+    """
+    d = np.arange(0, np.power(2, nSites), 1)
+    fullBasis = (
+        ((d[:, None] & (1 << np.arange(nSites))[::-1])) > 0).astype(int)
+    return fullBasis
+
+
+def createBosonBasis(nSites, Nmax, filling=None):
+    """
+    Computes the basis with no symmetry specified for the Fermionic Hubbard
+    model.
+
+    Parameters
+    ==========
+    nSites : int
+        The number of sites in the lattice
+    Nmax : int
+        The bosonic maximum occupation number for a site.
+    filling : int
+        The total number of bosonic excitations for each of the basis members.
+
+    Returns
+    -------
+    basisStates : numpy 2d array
+        Each row records a basis member of the full-basis.
+    """
+    if filling == 0:
+        raise Exception("filling of 0 is not supported")
+
+    maxN = Nmax+1
+    if filling is None:
+        maxx = np.power(maxN, nSites)
+        basisStates = np.zeros((maxx, nSites))
+        bff = 1
+    else:
+        maxx = np.power(maxN, nSites)
+        nStates = int(math.factorial(filling+nSites-1) / math.factorial(
+            nSites-1) / math.factorial(filling))
+
+        basisStates = np.zeros((nStates, nSites))
+        bff = 0
+
+    d = np.arange(0, maxx, 1)
+    k = 0
+    for i in range(1, maxx):
+        ss = np.base_repr(d[i], maxN, nSites-len(np.base_repr(d[i], maxN)))
+        rowb = [eval(j) for j in [*ss]]
+
+        if np.sum(rowb) != filling:
+            if filling is not None:
+                continue
+
+        basisStates[k+bff, :] = rowb
+        k = k+1
+
+    if filling is not None:
+        basisStates = np.delete(basisStates, np.arange(k+bff, nStates, 1), 0)
+
+    return basisStates

--- a/qutip_lattice/lattice_sp.py
+++ b/qutip_lattice/lattice_sp.py
@@ -30,10 +30,6 @@
 #    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
-
-
-__all__ = ['Lattice1d', 'cell_structures']
-
 from scipy.sparse import (csr_matrix)
 from qutip import (Qobj, tensor, basis, qeye, sigmax, sigmay, sigmaz)
 
@@ -43,6 +39,8 @@ try:
     import matplotlib.pyplot as plt
 except ImportError:
     pass
+
+__all__ = ['Lattice1d', 'cell_structures']
 
 
 def cell_structures(val_s=None, val_t=None, val_u=None):
@@ -1025,7 +1023,7 @@ class Lattice1d():
         chiral_op = self.distribute_operator(sigmaz())
         Hamt = self.Hamiltonian()
         anti_commutator_chi_H = chiral_op * Hamt + Hamt * chiral_op
-        is_null = (np.abs(anti_commutator_chi_H) < 1E-10).all()
+        is_null = (np.abs(anti_commutator_chi_H.full()) < 1E-10).all()
 
         if not is_null:
             raise Exception("The Hamiltonian does not have chiral symmetry!")

--- a/qutip_lattice/spinless_functions.py
+++ b/qutip_lattice/spinless_functions.py
@@ -1,0 +1,281 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, The QuTiP Project.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+from scipy.sparse import (csr_matrix)
+import scipy.io as spio
+from qutip import (Qobj, tensor, basis, qeye, isherm, sigmax, sigmay, sigmaz,
+                   create, destroy)
+
+import numpy as np
+
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    pass
+
+
+from scipy import sparse
+from scipy.sparse.linalg import eigs
+import operator as op
+from functools import reduce
+import copy
+from numpy import asarray
+import math
+from .tran_sym_functions import *
+from .lattice_operators import *
+
+__all__ = ['spinlessFermions_NoSymHamiltonian',
+           'spinlessFermions_nums_Trans', 'spinlessFermions_OnlyTrans',
+           'spinlessFermions_Only_nums']
+
+
+def spinlessFermions_nums_Trans(
+        paramT, latticeType, latticeSize, filling, kval, PP, PBC_x):
+    """
+    Calculates the Hamiltonian for a number and k-vector specified basis.
+
+    Parameters
+    ==========
+    paramT : float
+        The nearest neighbor hopping integral
+    latticeType : str
+        latticeType = 'cubic' indicates specification on a cubic lattice
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    filling : int
+        The total number of excitations for each of the basis members.
+    kval : int
+        The magnitude of the reciprocal lattice vector from the origin in units
+        of number of unit reciprocal lattice vectors
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+    PBC_x : int
+        indication (1) of specification of periodic boundary condition or (0)
+        open boundary condition.
+
+    Returns
+    -------
+    Qobj(H_down) : Qobj(csr_matrix)
+        The matrix elements that are associated with hopping between bosons on
+        nearest neighbor sites.
+    compDownStatesPerRepr_S : numpy 2d array
+        Each row indicates a basis vector chosen in the number and k-vector
+        symmetric basis.
+    """
+    kVector = np.arange(start=0, stop=2*np.pi, step=2*np.pi/latticeSize[0])
+    symOpInvariantsUp = np.array([np.power(1, np.arange(latticeSize[0]))])
+
+    kValue = kVector[kval]
+    nStatesDown = ncr(latticeSize[0], filling)
+    [basisStatesDown, integerBasisDown, indOnesDown
+     ] = createHeisenbergBasis(nStatesDown, latticeSize[0], filling)
+
+    [DownStatesPerk, Ind2kDown,
+     normDownHubbardStatesk] = combine2HubbardBasisOnlyTrans(
+     symOpInvariantsUp, basisStatesDown, latticeSize, kValue, PP, Nmax=1)
+    compDownStatesPerRepr_S = DownStatesPerk
+    compInd2ReprDown_S = Ind2kDown
+    symOpInvariantsUp_S = np.array([np.ones(latticeSize[0], )])
+    normHubbardStates_S = normDownHubbardStatesk
+    basisStates_S = createHeisenbergBasis(nStatesDown, latticeSize[0], filling)
+    [indNeighbors, nSites] = getNearestNeighbors(
+        latticeType=latticeType, latticeSize=latticeSize,
+        boundaryCondition=PBC_x)
+    H_down = calcHamiltonDownOnlyTrans(
+        compDownStatesPerRepr_S, compInd2ReprDown_S, paramT, indNeighbors,
+        normHubbardStates_S, symOpInvariantsUp_S, kValue, basisStates_S[0],
+        latticeSize, PP)
+
+    return [Qobj(H_down), compDownStatesPerRepr_S]
+
+
+def spinlessFermions_OnlyTrans(
+        paramT, latticeType, latticeSize, kval, PP, PBC_x):
+    """
+    Calculates the Hamiltonian for a k-vector specified basis.
+
+    Parameters
+    ==========
+    paramT : float
+        The nearest neighbor hopping integral
+    latticeType : str
+        latticeType = 'cubic' indicates specification on a cubic lattice
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    kval : int
+        The magnitude of the reciprocal lattice vector from the origin in units
+        of number of unit reciprocal lattice vectors
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+    PBC_x : int
+        indication (1) of specification of periodic boundary condition or (0)
+        open boundary condition.
+
+    Returns
+    -------
+    Qobj(H_down) : Qobj(csr_matrix)
+        The matrix elements that are associated with hopping between bosons on
+        nearest neighbor sites.
+    compDownStatesPerRepr_S : numpy 2d array
+        Each row indicates a basis vector chosen in the number and k-vector
+        symmetric basis.
+    """
+    kVector = np.arange(start=0, stop=2*np.pi, step=2*np.pi/latticeSize[0])
+    symOpInvariantsUp = np.array([np.power(1, np.arange(latticeSize[0]))])
+
+    kValue = kVector[kval]
+    basisStates_S = createHeisenbergfullBasis(latticeSize[0])
+
+    [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+     ] = combine2HubbardBasisOnlyTrans(
+     symOpInvariantsUp, basisStates_S, latticeSize, kValue, PP, Nmax=1)
+    compDownStatesPerRepr_S = DownStatesPerk
+    compInd2ReprDown_S = Ind2kDown
+    symOpInvariantsUp_S = np.array([np.ones(latticeSize[0], )])
+    normHubbardStates_S = normDownHubbardStatesk
+    [indNeighbors, nSites] = getNearestNeighbors(
+        latticeType=latticeType, latticeSize=latticeSize,
+        boundaryCondition=PBC_x)
+    H_down = calcHamiltonDownOnlyTrans(
+        compDownStatesPerRepr_S, compInd2ReprDown_S, paramT, indNeighbors,
+        normHubbardStates_S, symOpInvariantsUp_S, kValue, basisStates_S,
+        latticeSize, PP)
+
+    return [Qobj(H_down), compDownStatesPerRepr_S]
+
+
+def spinlessFermions_NoSymHamiltonian(
+        paramT, latticeType, latticeSize, PP, PBC_x):
+    """
+    Calculates the Hamiltonian for a no symmetry specified basis.
+
+    Parameters
+    ==========
+    paramT : float
+        The nearest neighbor hopping integral
+    latticeType : str
+        latticeType = 'cubic' indicates specification on a cubic lattice
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+    PBC_x : int
+        indication (1) of specification of periodic boundary condition or (0)
+        open boundary condition.
+
+    Returns
+    -------
+    Qobj(H_down) : Qobj(csr_matrix)
+        The matrix elements that are associated with hopping between bosons on
+        nearest neighbor sites.
+    compDownStatesPerRepr_S : numpy 2d array
+        Each row indicates a basis vector chosen in the number and k-vector
+        symmetric basis.
+    """
+    nSites = latticeSize[0]
+    kVector = np.arange(start=0, stop=2 * np.pi, step=2 * np.pi / nSites)
+    symOpInvariantsUp = np.array([np.zeros(latticeSize[0], )])
+    symOpInvariantsUp[0, 0] = 1
+    kval = 0
+    kValue = kVector[kval]
+    [indNeighbors, nSites] = getNearestNeighbors(
+        latticeType=latticeType, latticeSize=latticeSize,
+        boundaryCondition=PBC_x)
+
+    basisStates_S = createHeisenbergfullBasis(latticeSize[0])
+    [compDownStatesPerRepr, compInd2ReprDown, normHubbardStates
+     ] = combine2HubbardBasisOnlyTrans(
+     symOpInvariantsUp, basisStates_S, latticeSize, kValue, PP, Nmax=1)
+    H_down = calcHamiltonDownOnlyTrans(
+        compDownStatesPerRepr, compInd2ReprDown, paramT, indNeighbors,
+        normHubbardStates, symOpInvariantsUp, kValue, basisStates_S,
+        latticeSize, PP)
+
+    return [Qobj(H_down), basisStates_S]
+
+
+def spinlessFermions_Only_nums(
+        paramT, latticeType, latticeSize, filling, PP, PBC_x):
+    """
+    Calculates the Hamiltonian for a number specified basis.
+
+    Parameters
+    ==========
+    paramT : float
+        The nearest neighbor hopping integral
+    latticeType : str
+        latticeType = 'cubic' indicates specification on a cubic lattice
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    filling : int
+        The total number of excitations for each of the basis members.
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+    PBC_x : int
+        indication (1) of specification of periodic boundary condition or (0)
+        open boundary condition.
+
+    Returns
+    -------
+    Qobj(H_down) : Qobj(csr_matrix)
+        The matrix elements that are associated with hopping between bosons on
+        nearest neighbor sites.
+    compDownStatesPerRepr_S : numpy 2d array
+        Each row indicates a basis vector chosen in the number and k-vector
+        symmetric basis.
+    """
+    symOpInvariantsUp = np.array([np.zeros(latticeSize[0], )])
+    symOpInvariantsUp[0, 0] = 1
+    kValue = 0
+    nStatesDown = ncr(latticeSize[0], filling)
+    [basisStatesDown, integerBasisDown, indOnesDown
+     ] = createHeisenbergBasis(nStatesDown, latticeSize[0], filling)
+    [DownStatesPerk, Ind2kDown, normDownHubbardStatesk
+     ] = combine2HubbardBasisOnlyTrans(
+     symOpInvariantsUp, basisStatesDown, latticeSize, kValue, PP, Nmax=1)
+    compDownStatesPerRepr_S = DownStatesPerk
+    compInd2ReprDown_S = Ind2kDown
+    symOpInvariantsUp_S = symOpInvariantsUp
+    normHubbardStates_S = normDownHubbardStatesk
+    basisStates_S = createHeisenbergBasis(
+        nStatesDown, latticeSize[0], filling)
+
+    [indNeighbors, nSites] = getNearestNeighbors(
+        latticeType=latticeType, latticeSize=latticeSize,
+        boundaryCondition=PBC_x)
+    H_down = calcHamiltonDownOnlyTrans(
+        compDownStatesPerRepr_S, compInd2ReprDown_S, paramT, indNeighbors,
+        normHubbardStates_S, symOpInvariantsUp_S, kValue, basisStates_S[0],
+        latticeSize, PP)
+
+    return [Qobj(H_down), basisStates_S[0]]
+

--- a/qutip_lattice/tests/test_lattice.py
+++ b/qutip_lattice/tests/test_lattice.py
@@ -30,9 +30,13 @@
 #    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
+from scipy.sparse import (csr_matrix)
 import numpy as np
 import pytest
-import qutip
+import qutip_lattice
+from qutip import (Qobj, tensor, basis, qeye, isherm, sigmax, sigmay, sigmaz,
+                   sigmam, sigmap, num, create, destroy, mesolve, Options,
+                   projection, qdiags)
 
 _r2 = np.sqrt(2)
 
@@ -48,22 +52,22 @@ def _hamiltonian_expected(cells, periodic, sites_per_cell,
     """Expected Hamiltonian for the simple 1D lattice model"""
     # Within the cell, adjacent sites hop to each other, and it's always
     # non-periodic.
-    cell = qutip.qdiags([-np.ones(sites_per_cell - 1)]*2, [1, -1])
+    cell = qdiags([-np.ones(sites_per_cell - 1)]*2, [1, -1])
     # To hop to the cell one to the left, then you have to drop from the lowest
     # in-cell location to the highest in the other.
-    hop_left = qutip.qdiags(np.ones(cells - 1), 1)
+    hop_left = qdiags(np.ones(cells - 1), 1)
     if periodic and cells > 2:
         # If cells <= 2 then all cells border each other anyway.
-        hop_left += qutip.qdiags([1], -(cells - 1))
-    drop_site = -qutip.projection(sites_per_cell, sites_per_cell-1, 0)
+        hop_left += qdiags([1], -(cells - 1))
+    drop_site = -projection(sites_per_cell, sites_per_cell-1, 0)
     if np.prod(freedom) != 1:
         # Degenerate degrees of freedom per lattice site are unchanged.
-        identity = qutip.qeye(freedom)
-        cell = qutip.tensor(cell, identity)
-        drop_site = qutip.tensor(drop_site, identity)
-    out = (qutip.tensor(qutip.qeye(cells), cell)
-           + qutip.tensor(hop_left, drop_site)
-           + qutip.tensor(hop_left, drop_site).dag())
+        identity = qeye(freedom)
+        cell = tensor(cell, identity)
+        drop_site = tensor(drop_site, identity)
+    out = (tensor(qeye(cells), cell)
+           + tensor(hop_left, drop_site)
+           + tensor(hop_left, drop_site).dag())
     # Contract scalar spaces.
     dims = [x for x in [cells, sites_per_cell] + freedom
             if x != 1]
@@ -80,16 +84,15 @@ def _k_expected(cells):
 def _ssh_lattice(intra, inter,
                  cells=5, boundary="periodic", sites_per_cell=2,
                  freedom=[1]):
-    part_hamiltonian = qutip.Qobj(np.array([[0, intra], [intra, 0]]))
-    free_identity = qutip.qeye(freedom)
-    hamiltonian = qutip.tensor(part_hamiltonian, free_identity)
-    hopping = qutip.tensor(qutip.Qobj(np.array([[0, 0], [inter, 0]])),
-                           free_identity)
-    return qutip.Lattice1d(num_cell=cells, boundary=boundary,
-                           cell_num_site=sites_per_cell,
-                           cell_site_dof=freedom,
-                           Hamiltonian_of_cell=hamiltonian,
-                           inter_hop=hopping)
+    part_hamiltonian = Qobj(np.array([[0, intra], [intra, 0]]))
+    free_identity = qeye(freedom)
+    hamiltonian = tensor(part_hamiltonian, free_identity)
+    hopping = tensor(
+            Qobj(np.array([[0, 0], [inter, 0]])), free_identity)
+    return qutip_lattice.Lattice1d(
+            num_cell=cells, boundary=boundary, cell_num_site=sites_per_cell,
+            cell_site_dof=freedom, Hamiltonian_of_cell=hamiltonian,
+            inter_hop=hopping)
 
 
 # Energies for the SSH model with 4 cells, 2 orbitals and 2 spins, with
@@ -108,17 +111,16 @@ def _crow_lattice(coupling, phase_delay,
     See for example: https://www.doi.org/10.1103/PhysRevB.99.224201
     where `coupling` is $J$ and `phase_delay` is $\eta$.
     """
-    cell_hamiltonian = coupling * np.sin(phase_delay) * qutip.sigmax()
+    cell_hamiltonian = coupling * np.sin(phase_delay) * sigmax()
     phase_term = np.exp(1j * phase_delay)
     hopping = [
-        0.5 * coupling * qutip.qdiags([phase_term, phase_term.conj()], 0),
-        0.5 * coupling * qutip.sigmax(),
+        0.5 * coupling * qdiags([phase_term, phase_term.conj()], 0),
+        0.5 * coupling * sigmax(),
     ]
-    return qutip.Lattice1d(num_cell=cells, boundary=boundary,
-                           cell_num_site=sites_per_cell,
-                           cell_site_dof=freedom,
-                           Hamiltonian_of_cell=cell_hamiltonian,
-                           inter_hop=hopping)
+    return qutip_lattice.Lattice1d(
+            num_cell=cells, boundary=boundary, cell_num_site=sites_per_cell,
+            cell_site_dof=freedom, Hamiltonian_of_cell=cell_hamiltonian,
+            inter_hop=hopping)
 
 
 class TestLattice1d:
@@ -131,9 +133,9 @@ class TestLattice1d:
     def test_hamiltonian(self, cells, periodic, sites_per_cell, freedom):
         """Test that the lattice model produces the expected Hamiltonians."""
         boundary = "periodic" if periodic else "aperiodic"
-        lattice = qutip.Lattice1d(num_cell=cells, boundary=boundary,
-                                  cell_site_dof=freedom,
-                                  cell_num_site=sites_per_cell)
+        lattice = qutip_lattice.Lattice1d(
+                num_cell=cells, boundary=boundary, cell_site_dof=freedom,
+                cell_num_site=sites_per_cell)
         expected = _hamiltonian_expected(cells, periodic, sites_per_cell,
                                          freedom)
         assert lattice.Hamiltonian() == expected
@@ -142,7 +144,7 @@ class TestLattice1d:
         val_s = ['site0', 'site1']
         val_t = [' orb0', 'orb1']
         H_cell_form, inter_cell_T_form, H_cell, inter_cell_T =\
-            qutip.cell_structures(val_s, val_t)
+            qutip_lattice.cell_structures(val_s, val_t)
         c_H_form = [['<site0 orb0 H site0 orb0>',
                      '<site0 orb0 H site0orb1>',
                      '<site0 orb0 H site1 orb0>',
@@ -184,54 +186,60 @@ class TestLattice1d:
         assert (inter_cell_T == i_cell_T).all()
 
     def test_basis(self):
-        lattice_3242 = qutip.Lattice1d(num_cell=3, boundary="periodic",
-                                       cell_num_site=2, cell_site_dof=[4, 2])
+        lattice_3242 = qutip_lattice.Lattice1d(
+                num_cell=3, boundary="periodic", cell_num_site=2,
+                cell_site_dof=[4, 2])
         psi0 = lattice_3242.basis(1, 0, [2, 1])
         psi0dag_a = np.zeros((1, 48), dtype=complex)
         psi0dag_a[0, 21] = 1
-        psi0dag = qutip.Qobj(psi0dag_a, dims=[[1, 1, 1, 1], [3, 2, 4, 2]])
+        psi0dag = Qobj(psi0dag_a, dims=[[1, 1, 1, 1], [3, 2, 4, 2]])
         assert psi0 == psi0dag.dag()
 
     def test_distribute_operator(self):
-        lattice_412 = qutip.Lattice1d(num_cell=4, boundary="periodic",
-                                      cell_num_site=1, cell_site_dof=[2])
-        op = qutip.Qobj(np.array([[0, 1], [1, 0]]))
+        lattice_412 = qutip_lattice.Lattice1d(
+                num_cell=4, boundary="periodic", cell_num_site=1,
+                cell_site_dof=[2])
+        op = Qobj(np.array([[0, 1], [1, 0]]))
         op_all = lattice_412.distribute_operator(op)
-        sv_op_all = qutip.tensor(qutip.qeye(4), qutip.sigmax())
+        sv_op_all = tensor(qeye(4), sigmax())
         assert op_all == sv_op_all
 
     def test_operator_at_cells(self):
-        p_2222 = qutip.Lattice1d(num_cell=2, boundary="periodic",
-                                 cell_num_site=2, cell_site_dof=[2, 2])
-        op_0 = qutip.projection(2, 0, 1)
-        op_c = qutip.tensor(op_0, qutip.qeye([2, 2]))
+        p_2222 = qutip_lattice.Lattice1d(
+                num_cell=2, boundary="periodic", cell_num_site=2,
+                cell_site_dof=[2, 2])
+        op_0 = projection(2, 0, 1)
+        op_c = tensor(op_0, qeye([2, 2]))
         OP = p_2222.operator_between_cells(op_c, 1, 0)
-        T = qutip.projection(2, 1, 0)
-        QP = qutip.tensor(T, op_c)
+        T = projection(2, 1, 0)
+        QP = tensor(T, op_c)
         assert OP == QP
 
     def test_operator_between_cells(self):
-        lattice_412 = qutip.Lattice1d(num_cell=4, boundary="periodic",
-                                      cell_num_site=1, cell_site_dof=[2])
-        op = qutip.sigmax()
+        lattice_412 = qutip_lattice.Lattice1d(
+                num_cell=4, boundary="periodic", cell_num_site=1,
+                cell_site_dof=[2])
+        op = sigmax()
         op_sp = lattice_412.operator_at_cells(op, cells=[1, 2])
 
         aop_sp = np.zeros((8, 8), dtype=complex)
         aop_sp[2:4, 2:4] = aop_sp[4:6, 4:6] = op.full()
-        sv_op_sp = qutip.Qobj(aop_sp, dims=[[4, 2], [4, 2]])
+        sv_op_sp = Qobj(aop_sp, dims=[[4, 2], [4, 2]])
         assert op_sp == sv_op_sp
 
     def test_x(self):
-        lattice_3223 = qutip.Lattice1d(num_cell=3, boundary="periodic",
-                                       cell_num_site=2, cell_site_dof=[2, 3])
+        lattice_3223 = qutip_lattice.Lattice1d(
+                num_cell=3, boundary="periodic", cell_num_site=2,
+                cell_site_dof=[2, 3])
         test = lattice_3223.x().full()
         expected = np.diag([n for n in range(3) for _ in [None]*12])
         np.testing.assert_allclose(test, expected, atol=1e-12)
 
     def test_k(self):
         L = 7
-        lattice_L123 = qutip.Lattice1d(num_cell=L, boundary="periodic",
-                                       cell_num_site=1, cell_site_dof=[2, 3])
+        lattice_L123 = qutip_lattice.Lattice1d(
+                num_cell=L, boundary="periodic", cell_num_site=1,
+                cell_site_dof=[2, 3])
         kq = lattice_L123.k()
         kop = np.zeros((L, L), dtype=complex)
         for row in range(L):
@@ -242,14 +250,14 @@ class TestLattice1d:
                     kop[row, col] = 1 / (np.exp(2j * np.pi * (row - col)/L)-1)
         kt = np.kron(kop * 2 * np.pi / L, np.eye(6))
         dim_H = [[2, 2, 3], [2, 2, 3]]
-        kt = qutip.Qobj(kt, dims=dim_H)
+        kt = Qobj(kt, dims=dim_H)
         k_q = kq.eigenstates()[0]
         k_t = kt.eigenstates()[0]
         k_tC = k_t - (2*np.pi/L) * ((L-1) // 2)
         np.testing.assert_allclose(k_tC, k_q, atol=1e-12)
 
     @pytest.mark.parametrize(["lattice", "k_expected", "energies_expected"], [
-        pytest.param(qutip.Lattice1d(num_cell=8),
+        pytest.param(qutip_lattice.Lattice1d(num_cell=8),
                      _k_expected(8),
                      np.array([[2, np.sqrt(2), 0, -np.sqrt(2), -2,
                                 -np.sqrt(2), 0, np.sqrt(2)]]),
@@ -272,7 +280,7 @@ class TestLattice1d:
         hamiltonians = lattice.bulk_Hamiltonians()[1]
         for hamiltonian, system in zip(hamiltonians, eigensystems):
             for eigenvalue, eigenstate in zip(*system):
-                eigenstate = qutip.Qobj(eigenstate)
+                eigenstate = Qobj(eigenstate)
                 np.testing.assert_allclose((hamiltonian * eigenstate).full(),
                                            (eigenvalue * eigenstate).full(),
                                            atol=1e-12)
@@ -347,7 +355,7 @@ class TestIntegration:
             np.testing.assert_allclose(test.full(), expected, atol=1e-8)
         for hamiltonian, system in zip(test_bulk_h, test_bulk_system):
             for eigenvalue, eigenstate in zip(*system):
-                eigenstate = qutip.Qobj(eigenstate)
+                eigenstate = Qobj(eigenstate)
                 np.testing.assert_allclose((hamiltonian * eigenstate).full(),
                                            (eigenvalue * eigenstate).full(),
                                            atol=1e-12)
@@ -373,12 +381,12 @@ class TestIntegration:
         cells = 5
         lattice = _ssh_lattice(intra, inter,
                                cells=cells, sites_per_cell=2, freedom=[1])
-        Hin = qutip.Qobj([[0, intra], [intra, 0]])
-        Ht = qutip.Qobj([[0, 0], [inter, 0]])
-        D = qutip.qeye(cells)
-        T = qutip.qdiags([np.ones(cells-1), [1]], [1, 1-cells])
-        hopping = qutip.tensor(T, Ht)
-        expected_hamiltonian = qutip.tensor(D, Hin) + hopping + hopping.dag()
+        Hin = Qobj([[0, intra], [intra, 0]])
+        Ht = Qobj([[0, 0], [inter, 0]])
+        D = qeye(cells)
+        T = qdiags([np.ones(cells-1), [1]], [1, 1-cells])
+        hopping = tensor(T, Ht)
+        expected_hamiltonian = tensor(D, Hin) + hopping + hopping.dag()
         assert lattice.Hamiltonian() == expected_hamiltonian
 
         test_k, test_energies = lattice.get_dispersion()
@@ -400,3 +408,705 @@ class TestIntegration:
         _assert_angles_close(test_k, expected_k, atol=1e-12)
         np.testing.assert_allclose(test_energies, expected_energies,
                                    atol=1e-12)
+
+
+class Testfermions_Lattice1d:
+    def test_Ham_for_all_particle_nums(self):
+        fermions_Lattice1d = qutip_lattice.Lattice1d_fermions(3, "periodic", 1)
+        [Ham, basisSt] = fermions_Lattice1d.Hamiltonian(None, None)
+
+        bi2de = np.arange(3 - 1, -1, -1)
+        bi2de = np.power(2, bi2de)
+        intbSt = np.sum(basisSt * bi2de, axis=1)
+
+        expected = np.array([[0, 0, 0, 0, 0, 0, 0, 0],
+                             [0, 0, -1, 0, -1, 0, 0, 0],
+                             [0, -1, 0, 0, -1, 0, 0, 0],
+                             [0, 0, 0, 0, 0, -1, 1, 0],
+                             [0, -1, -1, 0, 0, 0, 0, 0],
+                             [0, 0, 0, -1, 0, 0, -1, 0],
+                             [0, 0, 0, 1, 0, -1, 0, 0],
+                             [0, 0, 0, 0, 0, 0, 0, 0]])
+
+        UsF = fermions_Lattice1d.NoSym_DiagTrans()
+
+        Hamiltonian_f1dk = UsF * Ham * UsF.dag()
+        Hamiltonian_f1dk = Hamiltonian_f1dk.full()
+
+#        [Ham_f1dk_0, bSt_f1dk_0] = fermions_Lattice1d.Hamiltonian(None, 0)
+#        [Ham_f1dk_1, bSt_f1dk_1] = fermions_Lattice1d.Hamiltonian(None, 1)
+#        [Ham_f1dk_2, bSt_f1dk_2] = fermions_Lattice1d.Hamiltonian(None, 2)
+
+        Ham_f1dk_0 = Hamiltonian_f1dk[0:4, 0:4]
+        Ham_f1dk_1 = Hamiltonian_f1dk[4:6, 4:6]
+        Ham_f1dk_2 = Hamiltonian_f1dk[6:8, 6:8]
+
+        UsFk_0 = fermions_Lattice1d.NoSym_DiagTrans_k(0)
+        UsFk_1 = fermions_Lattice1d.NoSym_DiagTrans_k(1)
+        UsFk_2 = fermions_Lattice1d.NoSym_DiagTrans_k(2)
+
+        Ham_f1dk0 = UsFk_0 * Ham * UsFk_0.dag()
+        Ham_f1dk1 = UsFk_1 * Ham * UsFk_1.dag()
+        Ham_f1dk2 = UsFk_2 * Ham * UsFk_2.dag()
+
+        [Ham_k0, bs] = fermions_Lattice1d.Hamiltonian(None, 0)
+        [Ham_k1, bs] = fermions_Lattice1d.Hamiltonian(None, 1)
+        [Ham_k2, bs] = fermions_Lattice1d.Hamiltonian(None, 2)
+
+        np.testing.assert_allclose(Ham_k0.full(), Ham_f1dk_0, atol=1e-8)
+        np.testing.assert_allclose(Ham_k1.full(), Ham_f1dk_1, atol=1e-8)
+        np.testing.assert_allclose(Ham_k2.full(), Ham_f1dk_2, atol=1e-8)
+
+        np.testing.assert_allclose(Ham_f1dk0.full(), Ham_f1dk_0, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk1.full(), Ham_f1dk_1, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk2.full(), Ham_f1dk_2, atol=1e-8)
+
+        np.testing.assert_allclose(Ham.full(), expected, atol=1e-8)
+        np.testing.assert_allclose(intbSt, np.arange(0, np.power(2, 3), 1),
+                                   atol=1e-8)
+
+    def test_Ham_for_fixed_particle_num(self):
+        fermions_Lattice1d = qutip_lattice.Lattice1d_fermions(5, "periodic", 1)
+        [Ham, basisSt] = fermions_Lattice1d.Hamiltonian(2, None)
+
+        expected = np.array([[0, -1, 0, 0, 0, 0, 0, 1, 0, 0],
+                             [-1, 0, -1, -1, 0, 0, 0, 0, 1, 0],
+                             [0, -1, 0, 0, -1, 0, 0, 0, 0, 0],
+                             [0, -1, 0, 0, -1, 0, -1, 0, 0, 1],
+                             [0, 0, -1, -1, 0, -1, 0, -1, 0, 0],
+                             [0, 0, 0, 0, -1, 0, 0, 0, -1, 0],
+                             [0, 0, 0, -1, 0, 0, 0, -1, 0, 0],
+                             [1, 0, 0, 0, -1, 0, -1, 0, -1, 0],
+                             [0, 1, 0, 0, 0, -1, 0, -1, 0, -1],
+                             [0, 0, 0, 1, 0, 0, 0, 0, -1, 0]])
+
+        UsF = fermions_Lattice1d.nums_DiagTrans(2)
+
+        Hamiltonian_f1dk = UsF * Ham * UsF.dag()
+        Hamiltonian_f1dk = Hamiltonian_f1dk.full()
+
+#        [Ham_f1dk_0, bSt_f1dk_0] = fermions_Lattice1d.Hamiltonian(2, 0)
+#        [Ham_f1dk_1, bSt_f1dk_1] = fermions_Lattice1d.Hamiltonian(2, 1)
+#        [Ham_f1dk_2, bSt_f1dk_2] = fermions_Lattice1d.Hamiltonian(2, 2)
+
+        Ham_f1dk_0 = Hamiltonian_f1dk[0:2, 0:2]
+        Ham_f1dk_1 = Hamiltonian_f1dk[2:4, 2:4]
+        Ham_f1dk_2 = Hamiltonian_f1dk[4:6, 4:6]
+
+        UsFk_0 = fermions_Lattice1d.nums_DiagTrans_k(2, 0)
+        UsFk_1 = fermions_Lattice1d.nums_DiagTrans_k(2, 1)
+        UsFk_2 = fermions_Lattice1d.nums_DiagTrans_k(2, 2)
+
+        Ham_f1dk0 = UsFk_0 * Ham * UsFk_0.dag()
+        Ham_f1dk1 = UsFk_1 * Ham * UsFk_1.dag()
+        Ham_f1dk2 = UsFk_2 * Ham * UsFk_2.dag()
+
+        [Ham_k0, bs] = fermions_Lattice1d.Hamiltonian(2, 0)
+        [Ham_k1, bs] = fermions_Lattice1d.Hamiltonian(2, 1)
+        [Ham_k2, bs] = fermions_Lattice1d.Hamiltonian(2, 2)
+
+        np.testing.assert_allclose(Ham_k0.full(), Ham_f1dk_0, atol=1e-8)
+        np.testing.assert_allclose(Ham_k1.full(), Ham_f1dk_1, atol=1e-8)
+        np.testing.assert_allclose(Ham_k2.full(), Ham_f1dk_2, atol=1e-8)
+
+        np.testing.assert_allclose(Ham_f1dk0.full(), Ham_f1dk_0, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk1.full(), Ham_f1dk_1, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk2.full(), Ham_f1dk_2, atol=1e-8)
+
+        np.testing.assert_allclose(Ham.full(), expected, atol=1e-8)
+
+
+class TestLattice1d_bose_Hubbard:
+    def test_Ham_for_all_particle_nums(self):
+        boseHubbardLattice1d = qutip_lattice.Lattice1d_bose_Hubbard(
+            3, boundary="periodic", t=1, U=1)
+        [Ham, basisSt] = boseHubbardLattice1d.Hamiltonian(2, None, None)
+
+        tri2de = np.arange(3 - 1, -1, -1)
+        tri2de = np.power(3, tri2de)
+        intbSt = np.sum(basisSt * tri2de, axis=1)
+
+        expected = np.zeros((27, 27))
+        expected[1, 3] = -1
+        expected[1, 9] = -1
+        expected[2, 2] = 2
+        expected[2, 4] = -1.41421356
+        expected[2, 10] = -1.41421356
+        expected[3, 1] = -1
+        expected[3, 9] = -1
+        expected[4, 2] = -1.41421356
+        expected[4, 6] = -1.41421356
+        expected[4, 10] = -1
+        expected[4, 12] = -1
+        expected[5, 5] = 2
+        expected[5, 7] = -2
+        expected[5, 11] = -1
+        expected[5, 13] = -1.41421356
+
+        expected[6, 4] = -1.41421356
+        expected[6, 6] = 2
+        expected[6, 12] = -1.41421356
+
+        expected[7, 5] = -2
+        expected[7, 7] = 2
+        expected[7, 13] = -1.41421356
+        expected[7, 15] = -1
+
+        expected[8, 8] = 4
+        expected[8, 14] = -1.41421356
+        expected[8, 16] = -1.41421356
+
+        expected[9, 1] = -1
+        expected[9, 3] = -1
+
+        expected[10, 2] = -1.41421356
+        expected[10, 4] = -1
+        expected[10, 12] = -1
+        expected[10, 18] = -1.41421356
+
+        expected[11, 5] = -1
+        expected[11, 11] = 2
+        expected[11, 13] = -1.41421356
+        expected[11, 19] = -2
+
+        expected[12, 4] = -1
+        expected[12, 6] = -1.41421356
+        expected[12, 10] = -1
+        expected[12, 18] = -1.41421356
+
+        expected[13, 5] = -1.41421356
+        expected[13, 7] = -1.41421356
+        expected[13, 11] = -1.41421356
+        expected[13, 15] = -1.41421356
+        expected[13, 19] = -1.41421356
+        expected[13, 21] = -1.41421356
+
+        expected[14, 8] = -1.41421356
+        expected[14, 14] = 2
+        expected[14, 16] = -2
+        expected[14, 20] = -1.41421356
+        expected[14, 22] = -2
+
+        expected[15, 7] = -1
+        expected[15, 13] = -1.41421356
+        expected[15, 15] = 2
+        expected[15, 21] = -2
+
+        expected[16, 8] = -1.41421356
+        expected[16, 14] = -2
+        expected[16, 16] = 2
+        expected[16, 22] = -2
+        expected[16, 24] = -1.41421356
+
+        expected[17, 17] = 4
+        expected[17, 23] = -2
+        expected[17, 25] = -2
+
+        expected[18, 10] = -1.41421356
+        expected[18, 12] = -1.41421356
+        expected[18, 18] = 2
+
+        expected[19, 11] = -2
+        expected[19, 13] = -1.41421356
+        expected[19, 19] = 2
+        expected[19, 21] = -1
+
+        expected[20, 14] = -1.41421356
+        expected[20, 20] = 4
+        expected[20, 22] = -1.41421356
+
+        expected[21, 13] = -1.41421356
+        expected[21, 15] = -2
+        expected[21, 19] = -1
+        expected[21, 21] = 2
+
+        expected[22, 14] = -2
+        expected[22, 16] = -2
+        expected[22, 20] = -1.41421356
+        expected[22, 22] = 2
+        expected[22, 24] = -1.41421356
+
+        expected[23, 17] = -2
+        expected[23, 23] = 4
+        expected[23, 25] = -2
+
+        expected[24, 16] = -1.41421356
+        expected[24, 22] = -1.41421356
+        expected[24, 24] = 4
+
+        expected[25, 17] = -2
+        expected[25, 23] = -2
+        expected[25, 25] = 4
+
+        expected[26, 26] = 6
+        expected = Qobj(expected)
+
+        UsF = boseHubbardLattice1d.NoSym_DiagTrans(None, 2)
+
+        Hamiltonian_f1dk = UsF * Ham * UsF.dag()
+        Hamiltonian_f1dk = Hamiltonian_f1dk.full()
+
+        Ham_f1dk_0 = Hamiltonian_f1dk[0:11, 0:11]
+        Ham_f1dk_1 = Hamiltonian_f1dk[11:19, 11:19]
+        Ham_f1dk_2 = Hamiltonian_f1dk[19:27, 19:27]
+
+        UsFk_0 = boseHubbardLattice1d.NoSym_DiagTrans_k(None, 0, 2)
+        UsFk_1 = boseHubbardLattice1d.NoSym_DiagTrans_k(None, 1, 2)
+        UsFk_2 = boseHubbardLattice1d.NoSym_DiagTrans_k(None, 2, 2)
+
+        Ham_f1dk0 = UsFk_0 * Ham * UsFk_0.dag()
+        Ham_f1dk1 = UsFk_1 * Ham * UsFk_1.dag()
+        Ham_f1dk2 = UsFk_2 * Ham * UsFk_2.dag()
+
+        [Ham_k0, bs] = boseHubbardLattice1d.Hamiltonian(2, None, 0)
+        [Ham_k1, bs] = boseHubbardLattice1d.Hamiltonian(2, None, 1)
+        [Ham_k2, bs] = boseHubbardLattice1d.Hamiltonian(2, None, 2)
+
+        np.testing.assert_allclose(Ham.full(), expected, atol=1e-8)
+#        np.testing.assert_allclose(Ham.full()[6][:], expected[6][0,:],
+#        atol=1e-8)
+
+        np.testing.assert_allclose(Ham_f1dk0.full(), Ham_f1dk_0, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk1.full(), Ham_f1dk_1, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk2.full(), Ham_f1dk_2, atol=1e-8)
+
+        np.testing.assert_allclose(Ham_k0.full(), Ham_f1dk_0, atol=1e-10)
+        np.testing.assert_allclose(Ham_k1.full(), Ham_f1dk_1, atol=1e-10)
+        np.testing.assert_allclose(Ham_k2.full(), Ham_f1dk_2, atol=1e-10)
+
+        np.testing.assert_allclose(intbSt, np.arange(0, np.power(3, 3), 1),
+                                   atol=1e-8)
+
+    def test_Ham_for_fixed_particle_num(self):
+        boseHubbardLattice1d = qutip_lattice.Lattice1d_bose_Hubbard(
+            3, boundary="periodic", t=1, U=1)
+        [Ham, basisSt] = boseHubbardLattice1d.Hamiltonian(2, 2, None)
+
+        expected = np.array([[2, -1.41421356, 0, -1.41421356, 0, 0],
+                             [-1.41421356, 0, -1.41421356, -1, -1, 0],
+                             [0, -1.41421356, 2, 0, -1.41421356, 0],
+                             [-1.41421356, -1, 0, 0, -1, -1.41421356],
+                             [0, -1, -1.41421356, -1, 0, -1.41421356],
+                             [0, 0, 0, -1.41421356, -1.41421356, 2]])
+
+        UsF = boseHubbardLattice1d.nums_DiagTrans(2, 2)
+
+        Hamiltonian_f1dk = UsF * Ham * UsF.dag()
+        Hamiltonian_f1dk = Hamiltonian_f1dk.full()
+
+        Ham_f1dk_0 = Hamiltonian_f1dk[0:2, 0:2]
+        Ham_f1dk_1 = Hamiltonian_f1dk[2:4, 2:4]
+        Ham_f1dk_2 = Hamiltonian_f1dk[4:6, 4:6]
+
+        UsFk_0 = boseHubbardLattice1d.nums_DiagTrans_k(2, 0, 2)
+        UsFk_1 = boseHubbardLattice1d.nums_DiagTrans_k(2, 1, 2)
+        UsFk_2 = boseHubbardLattice1d.nums_DiagTrans_k(2, 2, 2)
+
+        Ham_f1dk0 = UsFk_0 * Ham * UsFk_0.dag()
+        Ham_f1dk1 = UsFk_1 * Ham * UsFk_1.dag()
+        Ham_f1dk2 = UsFk_2 * Ham * UsFk_2.dag()
+
+        [Ham_k0, bs] = boseHubbardLattice1d.Hamiltonian(2, 2, 0)
+        [Ham_k1, bs] = boseHubbardLattice1d.Hamiltonian(2, 2, 1)
+        [Ham_k2, bs] = boseHubbardLattice1d.Hamiltonian(2, 2, 2)
+
+        np.testing.assert_allclose(Ham.full(), expected, atol=1e-8)
+#        np.testing.assert_allclose(Ham.full()[6][:], expected[6][0,:],
+#        atol=1e-8)
+
+        np.testing.assert_allclose(Ham_f1dk0.full(), Ham_f1dk_0, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk1.full(), Ham_f1dk_1, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk2.full(), Ham_f1dk_2, atol=1e-8)
+
+        np.testing.assert_allclose(Ham_k0.full(), Ham_f1dk_0, atol=1e-10)
+        np.testing.assert_allclose(Ham_k1.full(), Ham_f1dk_1, atol=1e-10)
+        np.testing.assert_allclose(Ham_k2.full(), Ham_f1dk_2, atol=1e-10)
+
+
+class TestLattice1d_fermi_Hubbard:
+    def test_Ham_for_all_particle_nums(self):
+        fermiHubbardLattice1d = qutip_lattice.Lattice1d_fermi_Hubbard(
+            num_sites=3, boundary="periodic", t=1, U=1, V=2)
+
+        [Ham, basStUp, basStDn, normHSts] = fermiHubbardLattice1d.Hamiltonian(
+            None, None)
+
+        bi2de = np.arange(3 - 1, -1, -1)
+        bi2de = np.power(2, bi2de)
+        intbSt = np.sum(basStUp * bi2de, axis=1)
+
+        eig_Ham = np.array([-4.00000000e+00, -3.00000000e+00, -3.00000000e+00,
+                            -2.73548950e+00,
+                            -1.00000000e+00, -1.00000000e+00, -6.45751311e-01,
+                            -6.45751311e-01,
+                            -4.11743462e-01, -4.11743462e-01, -1.11022302e-16,
+                            0.00000000e+00,
+                            0.00000000e+00,  1.31869258e-15,  1.00000000e+00,
+                            1.00000000e+00,
+                            1.00000000e+00,  2.52643973e+00,  3.00000000e+00,
+                            3.00000000e+00,
+                            3.52833390e+00,  3.52833390e+00,  3.58825654e+00,
+                            3.58825654e+00,
+                            4.00000000e+00,  4.64575131e+00,  4.64575131e+00,
+                            5.00000000e+00,
+                            5.00000000e+00,  5.00000000e+00,  5.00000000e+00,
+                            5.00000000e+00,
+                            5.20904977e+00,  6.88340956e+00,  6.88340956e+00,
+                            7.40614604e+00,
+                            7.52833390e+00,  7.52833390e+00,  8.00000000e+00,
+                            8.00000000e+00,
+                            8.00000000e+00,  8.00000000e+00,  8.00000000e+00,
+                            8.00000000e+00,
+                            9.00000000e+00,  9.40554543e+00,  1.05857864e+01,
+                            1.05857864e+01,
+                            1.08834096e+01,  1.08834096e+01,  1.20000000e+01,
+                            1.30000000e+01,
+                            1.34142136e+01,  1.34142136e+01,  1.50000000e+01,
+                            1.50000000e+01,
+                            1.51883085e+01,  1.60000000e+01,  1.60000000e+01,
+                            1.80000000e+01,
+                            1.90000000e+01,  1.90000000e+01,  2.20000000e+01,
+                            2.70000000e+01])
+
+#        expected = csr_matrix((dxy, (xs, ys)), shape=(64, 64))
+        UsF = fermiHubbardLattice1d.NoSym_DiagTrans()
+
+#        UsF = fermions_Lattice1d.NoSym_DiagTrans([3])
+
+        Hamiltonian_f1dk = UsF * Ham * UsF.dag()
+        Hamiltonian_f1dk = Hamiltonian_f1dk.full()
+
+#        [Ham_f1dk_0, bSt_f1dk_0] = fermions_Lattice1d.Hamiltonian(None, 0)
+#        [Ham_f1dk_1, bSt_f1dk_1] = fermions_Lattice1d.Hamiltonian(None, 1)
+#        [Ham_f1dk_2, bSt_f1dk_2] = fermions_Lattice1d.Hamiltonian(None, 2)
+
+        Ham_f1dk_0 = Hamiltonian_f1dk[0:20, 0:20]
+        Ham_f1dk_1 = Hamiltonian_f1dk[20:38, 20:38]
+        Ham_f1dk_2 = Hamiltonian_f1dk[38:56, 38:56]
+
+        UsFk_0 = fermiHubbardLattice1d.NoSym_DiagTrans_k(0)
+        UsFk_1 = fermiHubbardLattice1d.NoSym_DiagTrans_k(1)
+        UsFk_2 = fermiHubbardLattice1d.NoSym_DiagTrans_k(2)
+
+        Ham_f1dk0 = UsFk_0 * Ham * UsFk_0.dag()
+        Ham_f1dk1 = UsFk_1 * Ham * UsFk_1.dag()
+        Ham_f1dk2 = UsFk_2 * Ham * UsFk_2.dag()
+
+        [Ham_k0, bUp, bDn, normH] = fermiHubbardLattice1d.Hamiltonian(
+            None, None, 0)
+        [Ham_k1, bUp, bDn, normH] = fermiHubbardLattice1d.Hamiltonian(
+            None, None, 1)
+        [Ham_k2, bUp, bDn, normH] = fermiHubbardLattice1d.Hamiltonian(
+            None, None, 2)
+
+        np.testing.assert_allclose(Ham_k0.full(), Ham_f1dk_0, atol=1e-8)
+        np.testing.assert_allclose(Ham_k1.full(), Ham_f1dk_1, atol=1e-8)
+        np.testing.assert_allclose(Ham_k2.full(), Ham_f1dk_2, atol=1e-8)
+
+        np.testing.assert_allclose(Ham_f1dk0.full(), Ham_f1dk_0, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk1.full(), Ham_f1dk_1, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk2.full(), Ham_f1dk_2, atol=1e-8)
+
+        np.testing.assert_allclose(Ham.eigenenergies(), eig_Ham, atol=1e-8)
+        np.testing.assert_allclose(intbSt, np.arange(0, np.power(2, 3), 1),
+                                   atol=1e-8)
+
+    def test_Ham_for_fixed_particle_num(self):
+        fermiHubbardLattice1d = qutip_lattice.Lattice1d_fermi_Hubbard(
+            num_sites=3, boundary="periodic", t=1, U=1, V=2)
+
+        [Ham, basStUp, basStDn,
+            normHSts] = fermiHubbardLattice1d.Hamiltonian(2, 2)
+
+        expected = np.array([[10, -1, 1, -1, 0, 0, 1, 0, 0],
+                             [-1, 13, -1, 0, -1, 0, 0, 1, 0],
+                             [1, -1, 9, 0, 0, -1, 0, 0, 1],
+                             [-1, 0, 0, 9, -1, 1, -1, 0, 0],
+                             [0, -1, 0, -1, 10, -1, 0, -1, 0],
+                             [0, 0, -1, 1, -1, 13, 0, 0, -1],
+                             [1, 0, 0, -1, 0, 0, 13, -1, 1],
+                             [0, 1, 0, 0, -1, 0, -1, 9, -1],
+                             [0, 0, 1, 0, 0, -1, 1, -1, 10]])
+
+        UsF = fermiHubbardLattice1d.nums_DiagTrans(2, 2)
+
+#        UsF = fermions_Lattice1d.NoSym_DiagTrans([3])
+
+        Hamiltonian_f1dk = UsF * Ham * UsF.dag()
+        Hamiltonian_f1dk = Hamiltonian_f1dk.full()
+
+        Ham_f1dk_0 = Hamiltonian_f1dk[0:3, 0:3]
+        Ham_f1dk_1 = Hamiltonian_f1dk[3:6, 3:6]
+        Ham_f1dk_2 = Hamiltonian_f1dk[6:10, 6:10]
+
+        UsFk_0 = fermiHubbardLattice1d.nums_DiagTrans_k(2, 2, 0)
+        UsFk_1 = fermiHubbardLattice1d.nums_DiagTrans_k(2, 2, 1)
+        UsFk_2 = fermiHubbardLattice1d.nums_DiagTrans_k(2, 2, 2)
+
+        Ham_f1dk0 = UsFk_0 * Ham * UsFk_0.dag()
+        Ham_f1dk1 = UsFk_1 * Ham * UsFk_1.dag()
+        Ham_f1dk2 = UsFk_2 * Ham * UsFk_2.dag()
+
+        [Ham_k0, bUp, bDn, normH] = fermiHubbardLattice1d.Hamiltonian(2, 2, 0)
+        [Ham_k1, bUp, bDn, normH] = fermiHubbardLattice1d.Hamiltonian(2, 2, 1)
+        [Ham_k2, bUp, bDn, normH] = fermiHubbardLattice1d.Hamiltonian(2, 2, 2)
+
+        np.testing.assert_allclose(Ham_k0.full(), Ham_f1dk_0, atol=1e-8)
+        np.testing.assert_allclose(Ham_k1.full(), Ham_f1dk_1, atol=1e-8)
+        np.testing.assert_allclose(Ham_k2.full(), Ham_f1dk_2, atol=1e-8)
+
+        np.testing.assert_allclose(Ham_f1dk0.full(), Ham_f1dk_0, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk1.full(), Ham_f1dk_1, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk2.full(), Ham_f1dk_2, atol=1e-8)
+
+        np.testing.assert_allclose(Ham.full(), expected, atol=1e-8)
+
+
+class TestLattice1d_2c_hcb_Hubbard:
+    def test_Ham_for_all_particle_nums(self):
+        hc_2c_boseHubbardLattice1d = qutip_lattice.Lattice1d_2c_hcb_Hubbard(
+            num_sites=3, boundary="periodic", t=1, Uab=1)
+
+        [Ham, basStUp, basStDn,
+         normHSts] = hc_2c_boseHubbardLattice1d.Hamiltonian(
+            None, None)
+
+        bi2de = np.arange(3 - 1, -1, -1)
+        bi2de = np.power(2, bi2de)
+        intbSt = np.sum(basStUp * bi2de, axis=1)
+
+        eig_Ham = np.array([-3.70156212e+00, -3.37228132e+00, -3.37228132e+00,
+                            -2.70156212e+00,
+                            -2.00000000e+00, -2.00000000e+00, -2.00000000e+00,
+                            -2.00000000e+00,
+                            -1.00000000e+00, -1.00000000e+00, -1.00000000e+00,
+                            -1.00000000e+00,
+                            -7.32050808e-01, -7.32050808e-01, -7.32050808e-01,
+                            -7.32050808e-01,
+                            -4.14213562e-01, -4.14213562e-01, -3.37782489e-15,
+                            -1.38226956e-15,
+                            -1.05141839e-15, -6.05531379e-16, -2.92090965e-16,
+                            -1.11022302e-16,
+                            0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
+                            4.20115093e-16,
+                            1.68215103e-15,  5.85786438e-01,  5.85786438e-01,
+                            1.00000000e+00,
+                            1.00000000e+00,  1.00000000e+00,  1.00000000e+00,
+                            1.00000000e+00,
+                            1.00000000e+00,  1.00000000e+00,  1.00000000e+00,
+                            2.00000000e+00,
+                            2.00000000e+00,  2.00000000e+00,  2.00000000e+00,
+                            2.00000000e+00,
+                            2.37228132e+00,  2.37228132e+00,  2.41421356e+00,
+                            2.41421356e+00,
+                            2.70156212e+00,  2.73205081e+00,  2.73205081e+00,
+                            2.73205081e+00,
+                            2.73205081e+00,  3.00000000e+00,  3.00000000e+00,
+                            3.00000000e+00,
+                            3.00000000e+00,  3.00000000e+00,  3.00000000e+00,
+                            3.00000000e+00,
+                            3.00000000e+00,  3.41421356e+00,  3.41421356e+00,
+                            3.70156212e+00])
+
+        UsF = hc_2c_boseHubbardLattice1d.NoSym_DiagTrans()
+
+#        UsF = fermions_Lattice1d.NoSym_DiagTrans([3])
+
+        Hamiltonian_f1dk = UsF * Ham * UsF.dag()
+        Hamiltonian_f1dk = Hamiltonian_f1dk.full()
+
+#        [Ham_f1dk_0, bSt_f1dk_0] = fermions_Lattice1d.Hamiltonian(None, 0)
+#        [Ham_f1dk_1, bSt_f1dk_1] = fermions_Lattice1d.Hamiltonian(None, 1)
+#        [Ham_f1dk_2, bSt_f1dk_2] = fermions_Lattice1d.Hamiltonian(None, 2)
+
+        Ham_f1dk_0 = Hamiltonian_f1dk[0:20, 0:20]
+        Ham_f1dk_1 = Hamiltonian_f1dk[20:38, 20:38]
+        Ham_f1dk_2 = Hamiltonian_f1dk[38:56, 38:56]
+
+        UsFk_0 = hc_2c_boseHubbardLattice1d.NoSym_DiagTrans_k(0)
+        UsFk_1 = hc_2c_boseHubbardLattice1d.NoSym_DiagTrans_k(1)
+        UsFk_2 = hc_2c_boseHubbardLattice1d.NoSym_DiagTrans_k(2)
+
+        Ham_f1dk0 = UsFk_0 * Ham * UsFk_0.dag()
+        Ham_f1dk1 = UsFk_1 * Ham * UsFk_1.dag()
+        Ham_f1dk2 = UsFk_2 * Ham * UsFk_2.dag()
+
+        [Ham_k0, bUp, bDn, normH] = hc_2c_boseHubbardLattice1d.Hamiltonian(
+            None, None, 0)
+        [Ham_k1, bUp, bDn, normH] = hc_2c_boseHubbardLattice1d.Hamiltonian(
+            None, None, 1)
+        [Ham_k2, bUp, bDn, normH] = hc_2c_boseHubbardLattice1d.Hamiltonian(
+            None, None, 2)
+
+        np.testing.assert_allclose(Ham_k0.full(), Ham_f1dk_0, atol=1e-8)
+        np.testing.assert_allclose(Ham_k1.full(), Ham_f1dk_1, atol=1e-8)
+        np.testing.assert_allclose(Ham_k2.full(), Ham_f1dk_2, atol=1e-8)
+
+        np.testing.assert_allclose(Ham_f1dk0.full(), Ham_f1dk_0, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk1.full(), Ham_f1dk_1, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk2.full(), Ham_f1dk_2, atol=1e-8)
+
+        np.testing.assert_allclose(Ham.eigenenergies(), eig_Ham, atol=1e-8)
+        np.testing.assert_allclose(intbSt, np.arange(0, np.power(2, 3), 1),
+                                   atol=1e-8)
+
+    def test_Ham_for_fixed_particle_num(self):
+        hc_2c_boseHubbardLattice1d = qutip_lattice.Lattice1d_2c_hcb_Hubbard(
+            num_sites=3, boundary="periodic", t=1, Uab=1)
+
+        [Ham, basStUp, basStDn,
+            normHSts] = hc_2c_boseHubbardLattice1d.Hamiltonian(2, 2)
+
+        expected = np.array([[2, -1, -1, -1, 0, 0, -1, 0, 0],
+                             [-1, 1, -1, 0, -1, 0, 0, -1, 0],
+                             [-1, -1, 1, 0, 0, -1, 0, 0, -1],
+                             [-1, 0, 0, 1, -1, -1, -1, 0, 0],
+                             [0, -1, 0, -1, 2, -1, 0, -1, 0],
+                             [0, 0, -1, -1, -1, 1, 0, 0, -1],
+                             [-1, 0, 0, -1, 0, 0, 1, -1, -1],
+                             [0, -1, 0, 0, -1, 0, -1, 1, -1],
+                             [0, 0, -1, 0, 0, -1, -1, -1, 2]])
+
+        UsF = hc_2c_boseHubbardLattice1d.nums_DiagTrans(2, 2)
+
+#        UsF = fermions_Lattice1d.NoSym_DiagTrans([3])
+
+        Hamiltonian_f1dk = UsF * Ham * UsF.dag()
+        Hamiltonian_f1dk = Hamiltonian_f1dk.full()
+
+        Ham_f1dk_0 = Hamiltonian_f1dk[0:3, 0:3]
+        Ham_f1dk_1 = Hamiltonian_f1dk[3:6, 3:6]
+        Ham_f1dk_2 = Hamiltonian_f1dk[6:10, 6:10]
+
+        UsFk_0 = hc_2c_boseHubbardLattice1d.nums_DiagTrans_k(2, 2, 0)
+        UsFk_1 = hc_2c_boseHubbardLattice1d.nums_DiagTrans_k(2, 2, 1)
+        UsFk_2 = hc_2c_boseHubbardLattice1d.nums_DiagTrans_k(2, 2, 2)
+
+        Ham_f1dk0 = UsFk_0 * Ham * UsFk_0.dag()
+        Ham_f1dk1 = UsFk_1 * Ham * UsFk_1.dag()
+        Ham_f1dk2 = UsFk_2 * Ham * UsFk_2.dag()
+
+        [Ham_k0, bUp, bDn, normH] = hc_2c_boseHubbardLattice1d.Hamiltonian(
+            2, 2, 0)
+        [Ham_k1, bUp, bDn, normH] = hc_2c_boseHubbardLattice1d.Hamiltonian(
+            2, 2, 1)
+        [Ham_k2, bUp, bDn, normH] = hc_2c_boseHubbardLattice1d.Hamiltonian(
+            2, 2, 2)
+
+        np.testing.assert_allclose(Ham_k0.full(), Ham_f1dk_0, atol=1e-8)
+        np.testing.assert_allclose(Ham_k1.full(), Ham_f1dk_1, atol=1e-8)
+        np.testing.assert_allclose(Ham_k2.full(), Ham_f1dk_2, atol=1e-8)
+
+        np.testing.assert_allclose(Ham_f1dk0.full(), Ham_f1dk_0, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk1.full(), Ham_f1dk_1, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk2.full(), Ham_f1dk_2, atol=1e-8)
+
+        np.testing.assert_allclose(Ham.full(), expected, atol=1e-8)
+
+
+class Testhardcorebosons_Lattice1d:
+    def test_Ham_for_all_particle_nums(self):
+        hardcorebosons_Lattice1d = qutip_lattice.Lattice1d_hardcorebosons(
+                3, "periodic", 1)
+        [Ham, basisSt] = hardcorebosons_Lattice1d.Hamiltonian(None, None)
+
+        bi2de = np.arange(3 - 1, -1, -1)
+        bi2de = np.power(2, bi2de)
+        intbSt = np.sum(basisSt * bi2de, axis=1)
+
+        expected = np.array([[0, 0, 0, 0, 0, 0, 0, 0],
+                             [0, 0, -1, 0, -1, 0, 0, 0],
+                             [0, -1, 0, 0, -1, 0, 0, 0],
+                             [0, 0, 0, 0, 0, -1, -1, 0],
+                             [0, -1, -1, 0, 0, 0, 0, 0],
+                             [0, 0, 0, -1, 0, 0, -1, 0],
+                             [0, 0, 0, -1, 0, -1, 0, 0],
+                             [0, 0, 0, 0, 0, 0, 0, 0]])
+
+        UsF = hardcorebosons_Lattice1d.NoSym_DiagTrans()
+
+        Hamiltonian_f1dk = UsF * Ham * UsF.dag()
+        Hamiltonian_f1dk = Hamiltonian_f1dk.full()
+
+#        [Ham_f1dk_0, bSt_f1dk_0] = fermions_Lattice1d.Hamiltonian(None, 0)
+#        [Ham_f1dk_1, bSt_f1dk_1] = fermions_Lattice1d.Hamiltonian(None, 1)
+#        [Ham_f1dk_2, bSt_f1dk_2] = fermions_Lattice1d.Hamiltonian(None, 2)
+
+        Ham_f1dk_0 = Hamiltonian_f1dk[0:4, 0:4]
+        Ham_f1dk_1 = Hamiltonian_f1dk[4:6, 4:6]
+        Ham_f1dk_2 = Hamiltonian_f1dk[6:8, 6:8]
+
+        UsFk_0 = hardcorebosons_Lattice1d.NoSym_DiagTrans_k(0)
+        UsFk_1 = hardcorebosons_Lattice1d.NoSym_DiagTrans_k(1)
+        UsFk_2 = hardcorebosons_Lattice1d.NoSym_DiagTrans_k(2)
+
+        Ham_f1dk0 = UsFk_0 * Ham * UsFk_0.dag()
+        Ham_f1dk1 = UsFk_1 * Ham * UsFk_1.dag()
+        Ham_f1dk2 = UsFk_2 * Ham * UsFk_2.dag()
+
+        [Ham_k0, bs] = hardcorebosons_Lattice1d.Hamiltonian(None, 0)
+        [Ham_k1, bs] = hardcorebosons_Lattice1d.Hamiltonian(None, 1)
+        [Ham_k2, bs] = hardcorebosons_Lattice1d.Hamiltonian(None, 2)
+
+        np.testing.assert_allclose(Ham_k0.full(), Ham_f1dk_0, atol=1e-8)
+        np.testing.assert_allclose(Ham_k1.full(), Ham_f1dk_1, atol=1e-8)
+        np.testing.assert_allclose(Ham_k2.full(), Ham_f1dk_2, atol=1e-8)
+
+        np.testing.assert_allclose(Ham_f1dk0.full(), Ham_f1dk_0, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk1.full(), Ham_f1dk_1, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk2.full(), Ham_f1dk_2, atol=1e-8)
+
+        np.testing.assert_allclose(Ham.full(), expected, atol=1e-8)
+        np.testing.assert_allclose(intbSt, np.arange(0, np.power(2, 3), 1),
+                                   atol=1e-8)
+
+    def test_Ham_for_fixed_particle_num(self):
+        hardcorebosons_Lattice1d = qutip_lattice.Lattice1d_hardcorebosons(
+                5, "periodic", 1)
+        [Ham, basisSt] = hardcorebosons_Lattice1d.Hamiltonian(2, None)
+
+        expected = np.array([[0, -1, 0, 0, 0, 0, 0, -1, 0, 0],
+                             [-1, 0, -1, -1, 0, 0, 0, 0, -1, 0],
+                             [0, -1, 0, 0, -1, 0, 0, 0, 0, 0],
+                             [0, -1, 0, 0, -1, 0, -1, 0, 0, -1],
+                             [0, 0, -1, -1, 0, -1, 0, -1, 0, 0],
+                             [0, 0, 0, 0, -1, 0, 0, 0, -1, 0],
+                             [0, 0, 0, -1, 0, 0, 0, -1, 0, 0],
+                             [-1, 0, 0, 0, -1, 0, -1, 0, -1, 0],
+                             [0, -1, 0, 0, 0, -1, 0, -1, 0, -1],
+                             [0, 0, 0, -1, 0, 0, 0, 0, -1, 0.]])
+
+        UsF = hardcorebosons_Lattice1d.nums_DiagTrans(2)
+
+        Hamiltonian_f1dk = UsF * Ham * UsF.dag()
+        Hamiltonian_f1dk = Hamiltonian_f1dk.full()
+
+#        [Ham_f1dk_0, bSt_f1dk_0] = fermions_Lattice1d.Hamiltonian(2, 0)
+#        [Ham_f1dk_1, bSt_f1dk_1] = fermions_Lattice1d.Hamiltonian(2, 1)
+#        [Ham_f1dk_2, bSt_f1dk_2] = fermions_Lattice1d.Hamiltonian(2, 2)
+
+        Ham_f1dk_0 = Hamiltonian_f1dk[0:2, 0:2]
+        Ham_f1dk_1 = Hamiltonian_f1dk[2:4, 2:4]
+        Ham_f1dk_2 = Hamiltonian_f1dk[4:6, 4:6]
+
+        UsFk_0 = hardcorebosons_Lattice1d.nums_DiagTrans_k(2, 0)
+        UsFk_1 = hardcorebosons_Lattice1d.nums_DiagTrans_k(2, 1)
+        UsFk_2 = hardcorebosons_Lattice1d.nums_DiagTrans_k(2, 2)
+
+        Ham_f1dk0 = UsFk_0 * Ham * UsFk_0.dag()
+        Ham_f1dk1 = UsFk_1 * Ham * UsFk_1.dag()
+        Ham_f1dk2 = UsFk_2 * Ham * UsFk_2.dag()
+
+        [Ham_k0, bs] = hardcorebosons_Lattice1d.Hamiltonian(2, 0)
+        [Ham_k1, bs] = hardcorebosons_Lattice1d.Hamiltonian(2, 1)
+        [Ham_k2, bs] = hardcorebosons_Lattice1d.Hamiltonian(2, 2)
+
+        np.testing.assert_allclose(Ham_k0.full(), Ham_f1dk_0, atol=1e-8)
+        np.testing.assert_allclose(Ham_k1.full(), Ham_f1dk_1, atol=1e-8)
+        np.testing.assert_allclose(Ham_k2.full(), Ham_f1dk_2, atol=1e-8)
+
+        np.testing.assert_allclose(Ham_f1dk0.full(), Ham_f1dk_0, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk1.full(), Ham_f1dk_1, atol=1e-8)
+        np.testing.assert_allclose(Ham_f1dk2.full(), Ham_f1dk_2, atol=1e-8)
+
+        np.testing.assert_allclose(Ham.full(), expected, atol=1e-8)

--- a/qutip_lattice/topology.py
+++ b/qutip_lattice/topology.py
@@ -30,9 +30,6 @@
 #    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 #    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
-
-__all__ = ['berry_curvature', 'plot_berry_curvature']
-
 from qutip import (Qobj, tensor, basis, qeye, isherm, sigmax, sigmay, sigmaz)
 import numpy as np
 
@@ -40,6 +37,8 @@ try:
     import matplotlib.pyplot as plt
 except:
     pass
+
+__all__ = ['berry_curvature', 'plot_berry_curvature']
 
 
 def berry_curvature(eigfs):

--- a/qutip_lattice/tran_sym_functions.py
+++ b/qutip_lattice/tran_sym_functions.py
@@ -1,0 +1,1539 @@
+# This file is part of QuTiP: Quantum Toolbox in Python.
+#
+#    Copyright (c) 2011 and later, The QuTiP Project.
+#    All rights reserved.
+#
+#    Redistribution and use in source and binary forms, with or without
+#    modification, are permitted provided that the following conditions are
+#    met:
+#
+#    1. Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#
+#    2. Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#    3. Neither the name of the QuTiP: Quantum Toolbox in Python nor the names
+#       of its contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+#    PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+from scipy.sparse import (csr_matrix)
+import scipy.io as spio
+from qutip import (Qobj, tensor, basis, qeye, isherm, sigmax, sigmay, sigmaz,
+                   create, destroy)
+
+import numpy as np
+
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    pass
+
+
+from scipy import sparse
+from scipy.sparse.linalg import eigs
+import operator as op
+from functools import reduce
+import copy
+from numpy import asarray
+import math
+# from .lattice_operators import *
+
+__all__ = ['TransOperator', 'findReprOnlyTrans', 'Vterms_hamiltonDiagNumTrans',
+           'calcHamiltonDownOnlyTrans', 'calcHamiltonUpOnlyTrans',
+           'UnitaryTrans', 'UnitaryTrans_k', 'calcHamiltonDownOnlyTransBoson',
+           'HubbardPhase', 'cubicSymmetries', 'combine2HubbardBasisOnlyTrans',
+           'intersect_mtlb']
+
+
+def intersect_mtlb(a, b):
+    """
+    calculates the intersection of two sequences.
+
+    Parameters
+    ==========
+    a, b : np.array of int
+        a and b are the operands of the intersection
+
+    Returns
+    -------
+    c : csr_matrix
+        The matrix elements that are associated with hopping between spin-up
+        parts of the chosen basis.
+    ia[np.isin(a1, c)] : np.array of int
+        the indices of a chosen
+    ib[np.isin(b1, c) : np.array of int
+        the indices of b chosen
+    """
+    a1, ia = np.unique(a, return_index=True)
+    b1, ib = np.unique(b, return_index=True)
+    aux = np.concatenate((a1, b1))
+    aux.sort()
+    c = aux[:-1][aux[1:] == aux[:-1]]
+    return c, ia[np.isin(a1, c)], ib[np.isin(b1, c)]
+
+
+def cubicSymmetries(basisStates, symmetryValue, latticeSize, PP):
+    """
+    returns the basis vectors uniformly translated by a input vector and the
+    phase factor each basis member aquires.
+
+    Parameters
+    ==========
+    basisStates : np.array of int
+        a 2d numpy array with each basis vector as a row
+    symmetryValue : int
+        The number of sites the translation happens by
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+
+    Returns
+    -------
+    basisStates/basisStatesCopy : np.array of int
+        a 2d numpy array with each basis vector after translation as a row
+    symmetryPhases : 1d array of int
+        Each row is an int representing the phase factor acquired by the
+        corresponding basis member in the translation
+    """
+    [nBasisStates, nSites] = np.shape(basisStates)
+    symmetryPhases = np.zeros(nBasisStates)
+
+    if symmetryValue == 0:
+        symmetryPhases = np.power(1, symmetryPhases)
+
+    if symmetryValue != 0:
+        switchIndex = np.arange(1, nSites+1, 1)
+        switchIndex = np.roll(switchIndex, symmetryValue, axis=0)
+        basisStatesCopy = copy.deepcopy(basisStates)
+        basisStatesCopy[:, 0:nSites] = basisStatesCopy[:, switchIndex-1]
+        flippedSwitchIndex = switchIndex[::-1]
+
+        for iSites in range(1, nSites+1):
+            indSwitchIndSmallerSiteInd = flippedSwitchIndex[
+                flippedSwitchIndex <= iSites]
+            indUpTo = np.arange(0, np.size(indSwitchIndSmallerSiteInd), 1)
+            y = indSwitchIndSmallerSiteInd[
+                np.arange(0, indUpTo[indSwitchIndSmallerSiteInd == iSites], 1)]
+            x = np.sum(basisStates[:, y-1], axis=1)
+            r = basisStates[:, iSites-1]
+            n = np.multiply(r, x)
+            symmetryPhases = symmetryPhases + n
+        symmetryPhases = np.power(PP, symmetryPhases)
+
+    if symmetryValue == 0:
+        return [basisStates, symmetryPhases]
+    else:
+        return [basisStatesCopy, symmetryPhases]
+
+
+def HubbardPhase(
+        replBasisStates, hopIndicationMatrix, hoppingIndicesX, hoppingIndicesY,
+        PP):
+    """
+    For the Hilbert space with the basis with a specific k-symmetry,
+    computes the Hamiltonian elements holding the terms due to nearest neighbor
+    hopping between up-spin part of the basis.
+
+    Parameters
+    ==========
+    replBasisStates : list of 2d array of int
+        array of basisstates for each representation
+    hopIndicationMatrix : 2d array of int
+        array of site indices for the hopping from basisstates for each
+        representation
+    hoppingIndicesX : 2d array of int
+        array of site indices for the hopping from basisstates for each
+        representation
+    hoppingIndicesY : 2d array of int
+        array of site indices for the hopping indices from basisstates for each
+        representation
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+
+    Returns
+    -------
+    phase : csr_matrix
+        The matrix elements that are associated with hopping between spin-down
+        parts of the chosen basis.
+    """
+    [nReplBasisStates, nSites] = np.shape(replBasisStates)
+    # number of states and sites
+    siteInd = np.arange(1, nSites + 1, 1)
+    phase = np.zeros(nReplBasisStates)
+
+    HubbardPhases = np.zeros(nReplBasisStates)   # container for phases
+
+    for i in range(nReplBasisStates):
+        [dumpV, x] = hopIndicationMatrix.getrow(i).nonzero()
+        if np.size(x) == 0:
+            phase[i] = 0
+            continue
+
+        ToPow = replBasisStates[i, np.arange(x[0] + 1, x[1], 1)]
+
+        if np.size(ToPow):
+            phase[i] = np.power(PP, np.sum(ToPow, axis=0))
+        else:
+            phase[i] = 1
+    return phase
+
+
+def findReprOnlyTrans(basisStates, latticeSize, PP):
+    """
+    returns the symmetry information of the basis members.
+
+    Parameters
+    ==========
+    basisStates : np.array of int
+        a 2d numpy array with each basis vector as a row
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+
+    Returns
+    -------
+    basisRepr : np.array of int
+        each row represents a basis in representation
+    symOpInvariants : 2d array of int
+        Each row signifies symmtery operations that leave the corresponding
+        basis vector invariant
+    index2Repr : 1d array of int
+        Each integer is a pointer of the basis member
+    symOp2Repr : 1d array of int
+        Each row is the symmetry operation that leaves the representation
+        invariant
+    """
+    [nBasisStates, nSites] = np.shape(basisStates)
+    latticeDim = np.shape(latticeSize)
+    latticeDim = latticeDim[0]
+
+    nSitesY = latticeSize[0]
+    nSymmetricStates = nBasisStates * nSites
+    indTransPower = np.arange(0, nSites, 1)
+
+    symmetricBasis = np.zeros((nSymmetricStates, nSites))
+    symmetryPhases = np.ones(nSymmetricStates)
+
+    bi2de = np.arange(nSites-1, -1, -1)
+    bi2de = np.power(2, bi2de)
+
+    integerRepr = np.zeros(nBasisStates)
+    index2Repr = np.zeros(nBasisStates)
+    symOp2Repr = np.zeros(nBasisStates)
+    basisRepr = np.zeros((nBasisStates, nSites))
+
+    nRepr = 0
+    symOpInvariants = np.zeros((nBasisStates, nSites))
+
+    for rx1D in range(nSites):
+        ind = rx1D + 1
+        indCycle = np.arange(
+            ind, nSymmetricStates - nSites + ind+1, nSites) - 1
+
+        [symmetricBasis[indCycle, :], symmetryPhases[
+            indCycle]] = cubicSymmetries(basisStates, rx1D, latticeSize, PP)
+
+    for iBasis in range(nBasisStates):
+        # index to pick out one spec. symmetry operation
+        indSymmetry = np.arange(iBasis*nSites, (iBasis+1)*nSites, 1)
+        # pick binary form of one symmetry op. and calculate integer
+
+        specSymBasis = symmetricBasis[indSymmetry, :]
+
+        specInteger = np.sum(specSymBasis*bi2de, axis=1)
+        specPhases = symmetryPhases[indSymmetry]
+
+        # find unique integers
+        [uniqueInteger, indUniqueInteger, conversionIndex2UniqueInteger
+         ] = np.unique(specInteger, return_index=True, return_inverse=True)
+
+        if uniqueInteger[0] in integerRepr:
+            locs = np.argwhere(integerRepr == uniqueInteger[0])
+            alreadyRepr = locs[0][0] + 1
+            # position of corresponding repr. times phase factor
+            index2Repr[iBasis] = alreadyRepr*specPhases[indUniqueInteger[0]]
+            # symmetry operations needed to get there, for 1D easy: position in
+            # symmetry group-1, for 2D only translation too : rx*Ly + ry
+            symOp2Repr[iBasis] = indUniqueInteger[0]
+        else:
+            # integer value of repr. (needed in the loop)
+            integerRepr[nRepr] = uniqueInteger[0]
+            # binary repr. (output) if its a repr. its always first element
+            # since list is sorted!:
+            basisRepr[nRepr][:] = specSymBasis[0][:]
+            # mask for same element as starting state
+            sameElementAsFirst = conversionIndex2UniqueInteger == 0
+
+            # store phases and translation value for invariant states
+            # column position of non zero elements determines the combination
+            # of translational powers rx, and ry: columnPos = rx*Ly + ry + 1
+            symOpInvariants[nRepr][indTransPower[sameElementAsFirst]
+                                   ] = specPhases[sameElementAsFirst]
+            # save index for hash table connecting basis states and repr.
+            index2Repr[iBasis] = nRepr + 1
+            # incrNease index for every found comp. repr.
+            nRepr = nRepr+1
+
+    # cut not used elements of container
+    basisRepr = np.delete(basisRepr, np.arange(nRepr, nBasisStates, 1), 0)
+    symOpInvariants = np.delete(
+        symOpInvariants, np.arange(nRepr, nBasisStates, 1), 0)
+
+    return [basisRepr, symOpInvariants, index2Repr, symOp2Repr]
+
+
+def combine2HubbardBasisOnlyTrans(
+        symOpInvariantsUp, basisStatesDown, latticeSize, kValue, PP, Nmax=1):
+    """
+    combines the spin-up and spin-down basis members according to a combined
+    translational symmetry specified by the reciprocal lattice vector.
+
+    Parameters
+    ==========
+    symOpInvariants : 2d array of int
+        Each row signifies symmtery operations that leave the corresponding
+        basis vector invariant
+    basisStatesDown : np.array of int
+        a 2d numpy array with each basis vector as a row
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    kValue : float
+        The length of the reciprocal lattice vector
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+    Nmax : int
+        The maximum occupation number for a lattice site; chosen by user for
+        bosons, for fermions it is necessarily 1.
+
+    Returns
+    -------
+    downStatesPerRepr : list of 2d array of int
+        array of basisstates for each representation
+    index2ReprDown : 2d array of int
+        Each row represents the token for set of down spin vectors
+        corresponding to the upspin representative
+    normHubbardStates : dict of 1d array of floats
+        Normalized basis vectors for the Hubbard model
+    """
+    [nReprUp, dumpV] = np.shape(symOpInvariantsUp)
+    [nBasisStatesDown, nSites] = np.shape(basisStatesDown)
+    [latticeDim, ] = np.shape(latticeSize)
+    nSitesY = latticeSize[0]
+
+    # umrechnung bin2dez
+    bi2de = np.arange(nSites-1, -1, -1)
+    bi2de = np.power(Nmax+1, bi2de)
+
+    intDownStates = np.sum(basisStatesDown*bi2de, axis=1)
+    indexDownStates = np.arange(1, nBasisStatesDown+1, 1)
+
+    downStatesPerRepr = {}
+    index2ReprDown = {}
+    normHubbardStates = {}
+
+    flagAlreadySaved = 0
+    for iReprUp in range(nReprUp):
+        transStates = 0
+        transPhases = 0
+        expPhase = 0
+        transIndexUpT = np.argwhere(symOpInvariantsUp[iReprUp, :])
+        transIndexUp = transIndexUpT[:, 0]
+
+        transPhasesUp = symOpInvariantsUp[iReprUp, transIndexUp]
+        ntransIndexUp = np.size(transIndexUp)
+
+        if ntransIndexUp == 1:
+            downStatesPerRepr[iReprUp] = basisStatesDown
+            index2ReprDown[iReprUp] = indexDownStates
+            normHubbardStates[iReprUp] = np.ones(nBasisStatesDown) / nSites
+
+        else:
+            transIndexUp = np.delete(transIndexUp, np.arange(0, 1, 1), 0)
+            transPhasesUp = np.delete(transPhasesUp, np.arange(0, 1, 1), 0)
+
+            maskStatesSmaller = np.ones(nBasisStatesDown)
+            sumPhases = np.ones(nBasisStatesDown, dtype=complex)
+
+            translationPower = transIndexUp
+            transPowerY = np.mod(transIndexUp, nSitesY)
+
+            for iTrans in range(0, ntransIndexUp-1, 1):
+                [transStates, transPhases] = cubicSymmetries(
+                    basisStatesDown, translationPower[iTrans], latticeSize, PP)
+
+                expPhase = np.exp(1J * kValue * translationPower[iTrans])
+                intTransStates = np.sum(transStates * bi2de, axis=1)
+                DLT = np.argwhere(intDownStates <= intTransStates)
+                DLT = DLT[:, 0]
+                set1 = np.zeros(nBasisStatesDown)
+                set1[DLT] = 1
+                maskStatesSmaller = np.logical_and(maskStatesSmaller,  set1)
+                DLT = np.argwhere(intDownStates == intTransStates)
+
+                sameStates = DLT[:, 0]
+                sumPhases[sameStates] = sumPhases[
+                    sameStates] + expPhase * transPhasesUp[
+                        iTrans] * transPhases[sameStates]
+
+            specNorm = np.abs(sumPhases) / nSites
+            DLT = np.argwhere(specNorm > 1e-10)
+            DLT = DLT[:, 0]
+
+            maskStatesComp = np.zeros(nBasisStatesDown)
+            maskStatesComp[DLT] = 1
+
+            maskStatesComp = np.logical_and(maskStatesSmaller, maskStatesComp)
+            downStatesPerRepr[iReprUp] = basisStatesDown[maskStatesComp, :]
+            index2ReprDown[iReprUp] = indexDownStates[maskStatesComp]
+            normHubbardStates[iReprUp] = specNorm[maskStatesComp]
+
+    return [downStatesPerRepr, index2ReprDown, normHubbardStates]
+
+
+def Vterms_hamiltonDiagNumTrans(
+        basisReprUp, compDownStatesPerRepr, paramT, indNeighbors, kValue,
+        paramV, PP):
+    """
+    For the Hilbert space with the basis with a specific number and k-symmetry,
+    computes the diagonal Hamiltonian holding the terms due to nearest neighbor
+    interaction V.
+
+    Parameters
+    ==========
+    basisReprUp : np.array of int
+        each row represents a basis in representation
+    compDownStatesPerRepr : list of 2d array of int
+        array of basisstates for each representation
+    paramT : float
+        The nearest neighbor hopping integral
+    indNeighbors : list of list of str
+        a list of indices that are the nearest neighbors of the indexed
+        lattice site
+    kValue : float
+        The length of the reciprocal lattice vector
+    paramU : float
+        The V parameter in the extended Hubbard model
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+
+    Returns
+    -------
+    HdiagV : csr_matrix
+        The diagonal matrix with the diagonal entries due to the V interaction
+        of the extended Hubbard model.
+
+    """
+    [nReprUp, nSites] = np.shape(basisReprUp)
+
+    xFinal = {}
+    yFinal = {}
+    HVelem = {}
+    cumulIndex = np.zeros(nReprUp+1, dtype=int)
+    cumulIndex[0] = 0
+    sumL = 0
+    for iReprUp in range(nReprUp):
+        sumL = sumL + np.shape(compDownStatesPerRepr[iReprUp])[0]
+        cumulIndex[iReprUp + 1] = sumL
+
+        basisStatesUp = basisReprUp[iReprUp]
+        basisStatesDown = compDownStatesPerRepr[iReprUp]
+
+        B2 = basisStatesUp[indNeighbors]
+        B2 = np.logical_xor(basisStatesUp, B2)
+        TwoA = np.argwhere(B2)
+        USp = (2 * np.count_nonzero(basisStatesUp) - len(TwoA))/2
+        [nBasisStatesDown, dumpV] = np.shape(basisStatesDown)
+
+        xFinal[iReprUp] = cumulIndex[iReprUp] + np.arange(nBasisStatesDown)
+        yFinal[iReprUp] = cumulIndex[iReprUp] + np.arange(nBasisStatesDown)
+        HVelem[iReprUp] = USp * paramV * np.ones(nBasisStatesDown)
+        B2 = basisStatesDown[:, indNeighbors]
+        B2 = np.logical_xor(basisStatesDown, B2)
+
+        HVelem[iReprUp] = HVelem[iReprUp] + paramV * (2 * np.count_nonzero(
+            basisStatesDown, 1) - np.count_nonzero(B2, 1))/2
+
+        B2 = basisStatesDown[:, indNeighbors]
+        B2 = np.logical_xor(basisStatesUp, B2)
+
+        HVelem[iReprUp] = HVelem[iReprUp] + 2 * paramV * (
+            2 * np.count_nonzero(basisStatesDown, 1) - np.count_nonzero(
+                B2, 1))/2
+
+    xFinalA = np.zeros(cumulIndex[-1], dtype=int)
+    yFinalA = np.zeros(cumulIndex[-1], dtype=int)
+    HVelemA = np.zeros(cumulIndex[-1], dtype=complex)
+
+    for iReprUp in range(nReprUp):
+        xFinalA[cumulIndex[iReprUp]:cumulIndex[iReprUp + 1]] = xFinal[iReprUp]
+        yFinalA[cumulIndex[iReprUp]:cumulIndex[iReprUp + 1]] = yFinal[iReprUp]
+        HVelemA[cumulIndex[iReprUp]:cumulIndex[iReprUp + 1]] = HVelem[iReprUp]
+
+    FinL = np.shape(xFinalA)[0]
+    for ii in range(FinL):
+        for jj in range(ii + 1, FinL, 1):
+
+            if xFinalA[ii] == xFinalA[jj] and yFinalA[ii] == yFinalA[jj]:
+                HVelemA[ii] = HVelemA[ii] + HVelemA[jj]
+
+                HVelemA[jj] = 0
+                xFinalA[jj] = cumulIndex[-1] - 1
+                yFinalA[jj] = cumulIndex[-1] - 1
+
+    HdiagV = sparse.csr_matrix((HVelemA, (xFinalA, yFinalA)), shape=(
+        cumulIndex[-1], cumulIndex[-1]))
+    return (HdiagV + HdiagV.transpose().conjugate())/2
+
+
+def calcHamiltonDownOnlyTrans(
+        compDownStatesPerRepr, compInd2ReprDown, paramT, indNeighbors,
+        normHubbardStates, symOpInvariantsUp, kValue, basisStatesDown,
+        latticeSize, PP):
+    """
+    For the Hilbert space with the basis with a specific k-symmetry,
+    computes the Hamiltonian elements holding the terms due to nearest neighbor
+    hopping.
+
+    Parameters
+    ==========
+    compDownStatesPerRepr : list of 2d array of int
+        array of basisstates for each representation
+    compInd2ReprDown : np.array of int
+        each row represents a basis in representation
+    paramT : float
+        The nearest neighbor hopping integral
+    indNeighbors : list of list of str
+        a list of indices that are the nearest neighbors of the indexed
+        lattice site
+    normHubbardStates : dict of 1d array of floats
+        Normalized basis vectors for the Hubbard model
+    symOpInvariants : 2d array of int
+        Each row signifies symmtery operations that leave the corresponding
+        basis vector invariant
+    kValue : float
+        The length of the reciprocal lattice vector
+    basisStatesDown : np.array of int
+        a 2d numpy array with each basis vector as a row
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+
+    Returns
+    -------
+    H_down : csr_matrix
+        The matrix elements that are associated with hopping between spin-down
+        parts of the chosen basis.
+
+    """
+    [nReprUp, nSites] = np.shape(symOpInvariantsUp)
+    nSitesY = latticeSize[0]
+    bin2dez = np.arange(nSites - 1, -1, -1)
+    bin2dez = np.power(2, bin2dez)
+
+    nTranslations = np.zeros(nReprUp, dtype=int)
+    cumulIndex = np.zeros(nReprUp+1, dtype=int)
+    cumulIndex[0] = 0
+    sumL = 0
+    for iReprUp in range(nReprUp):
+        rt = symOpInvariantsUp[iReprUp, :]
+        nTranslations[iReprUp] = np.count_nonzero(
+            np.logical_and(rt != 0, rt != 2))
+        sumL = sumL + np.size(normHubbardStates[iReprUp])
+        cumulIndex[iReprUp+1] = sumL
+
+    # number of dimensions of lattice:
+    [nDims, ] = np.shape(indNeighbors)
+    # number of basis states of whole down spin basis
+    [nBasisSatesDown, dumpV] = np.shape(basisStatesDown)
+    # final x and y indices and phases
+    B2 = basisStatesDown[:, indNeighbors]
+    B2 = np.logical_xor(basisStatesDown, B2)
+    TwoA = np.argwhere(B2)
+    xIndWholeBasis = TwoA[:, 0]
+    d = TwoA[:, 1]
+
+    f = indNeighbors[d]
+    f1 = np.append(d, f, axis=0)
+    d1 = np.append(np.arange(np.count_nonzero(B2)), np.arange(
+        np.count_nonzero(B2)), axis=0)
+    F_i = basisStatesDown[np.sum(B2, axis=1) == 0, :]
+    F = np.sum(F_i*bin2dez, axis=1)
+    B2 = basisStatesDown[xIndWholeBasis, :]
+    d1 = sparse.csr_matrix((np.ones(np.size(d1)),  (d1, f1)), shape=(
+        np.max(d1) + 1, nSites))
+    phasesWholeBasis = HubbardPhase(B2, d1, d, f, PP)
+    d = np.logical_xor(d1.todense(), B2)
+    prodd = d * np.reshape(bin2dez, (nSitesY, 1))
+    d = np.sum(prodd, axis=1)
+    d = np.squeeze(np.asarray(d))
+    f = np.append(d, F, axis=0)
+    [uniqueInteger, indUniqueInteger, B2] = np.unique(f, return_index=True,
+                                                      return_inverse=True)
+    yIndWholeBasis = B2[np.arange(0, np.size(xIndWholeBasis), 1)]
+    sums = 0
+    cumulIndFinal = np.zeros(nReprUp + 1, dtype=int)
+    cumulIndFinal[0] = sums
+
+    xFinal = {}
+    yFinal = {}
+    phasesFinal = {}
+    for iReprUp in range(nReprUp):
+        specNumOfTrans = nTranslations[iReprUp]
+        if specNumOfTrans == 1:
+            xFinal[iReprUp] = cumulIndex[iReprUp] + xIndWholeBasis
+            yFinal[iReprUp] = cumulIndex[iReprUp] + yIndWholeBasis
+            phasesFinal[iReprUp] = phasesWholeBasis
+
+            sums = sums + np.shape(xIndWholeBasis)[0]
+            cumulIndFinal[iReprUp+1] = sums
+            continue
+        specInd2ReprDown = compInd2ReprDown[iReprUp] - 1
+        nSpecStatesDown = np.size(specInd2ReprDown)
+        indexTransform = np.zeros(nBasisSatesDown)
+        indexTransform[specInd2ReprDown] = np.arange(1, nSpecStatesDown + 1, 1)
+        xIndSpec = indexTransform[xIndWholeBasis]
+        yIndSpec = indexTransform[yIndWholeBasis]
+        nBLe = np.size(xIndWholeBasis)
+        DLT = np.argwhere(xIndSpec != 0)
+        DLT = DLT[:, 0]
+        maskStartingStates = np.zeros(nBLe, dtype=bool)
+        maskStartingStates[DLT] = 1
+        DLT = np.argwhere(yIndSpec != 0)
+        DLT = DLT[:, 0]
+        mask_ynonzero = np.zeros(nBLe)
+        mask_ynonzero[DLT] = 1
+        maskCompatible = np.logical_and(maskStartingStates, mask_ynonzero)
+        xIndOfReprDown = {}
+        yIndOfReprDown = {}
+        hoppingPhase = {}
+        for iTrans in range(specNumOfTrans - 1):
+            xIndOfReprDown[iTrans + 1] = xIndSpec[maskStartingStates]
+            hoppingPhase[iTrans + 1] = phasesWholeBasis[maskStartingStates]
+
+        xIndSpec = xIndSpec[maskCompatible]
+        yIndSpec = yIndSpec[maskCompatible]
+        phasesSpec = phasesWholeBasis[maskCompatible]
+        xIndOfReprDown[0] = xIndSpec
+        yIndOfReprDown[0] = yIndSpec
+        hoppingPhase[0] = phasesSpec
+        specStatesDown = compDownStatesPerRepr[iReprUp]
+        intSpecStatesDown = np.sum(specStatesDown * bin2dez, axis=1)
+        hoppedStates = basisStatesDown[yIndWholeBasis[maskStartingStates], :]
+        DLT = np.argwhere(symOpInvariantsUp[iReprUp, :])
+        translationPower = DLT[:, 0]
+        phasesFromTransInvariance = symOpInvariantsUp[iReprUp, DLT]
+        phasesFromTransInvariance = phasesFromTransInvariance[:, 0]
+
+        cumulIndOfRepr = np.zeros(specNumOfTrans+1, dtype=int)
+        cumulIndOfRepr[0] = 0
+        cumulIndOfRepr[1] = np.size(xIndSpec)
+        sumIOR = np.size(xIndSpec)
+
+        for iTrans in range(specNumOfTrans - 1):
+            specTrans = translationPower[iTrans + 1]
+            [transBasis, transPhases] = cubicSymmetries(
+                hoppedStates, specTrans, latticeSize, PP)
+            expPhases = np.exp(1J * kValue * specTrans)
+            phaseUpSpinTransInv = phasesFromTransInvariance[iTrans + 1]
+            PhaseF = expPhases * np.multiply(transPhases, phaseUpSpinTransInv)
+            hoppingPhase[iTrans + 1] = np.multiply(hoppingPhase[
+                iTrans + 1], PhaseF)
+            intValues = np.sum(transBasis * bin2dez, axis=1)
+            maskInBasis = np.in1d(intValues, intSpecStatesDown)
+            intValues = intValues[maskInBasis]
+            xIndOfReprDown[iTrans + 1] = xIndOfReprDown[
+                iTrans + 1][maskInBasis]
+            hoppingPhase[iTrans + 1] = hoppingPhase[iTrans + 1][maskInBasis]
+            F = np.setdiff1d(intSpecStatesDown, intValues)
+            f = np.append(intValues, F)
+
+            [uniqueInteger, indUniqueInteger, B2] = np.unique(
+                f, return_index=True, return_inverse=True)
+
+            yIndOfReprDown[iTrans + 1] = B2[np.arange(0, np.size(
+                xIndOfReprDown[iTrans + 1]), 1)] + 1
+            sumIOR = sumIOR + np.size(xIndOfReprDown[iTrans+1])
+            cumulIndOfRepr[iTrans+2] = sumIOR
+
+        xIndOfReprDownA = np.zeros(cumulIndOfRepr[-1])
+        yIndOfReprDownA = np.zeros(cumulIndOfRepr[-1])
+        hoppingPhaseA = np.zeros(cumulIndOfRepr[-1], dtype=complex)
+        for iTrans in range(specNumOfTrans):
+            xIndOfReprDownA[cumulIndOfRepr[iTrans]: cumulIndOfRepr[iTrans + 1]
+                            ] = xIndOfReprDown[iTrans] - 1
+            yIndOfReprDownA[cumulIndOfRepr[iTrans]: cumulIndOfRepr[iTrans + 1]
+                            ] = yIndOfReprDown[iTrans] - 1
+            hoppingPhaseA[cumulIndOfRepr[iTrans]: cumulIndOfRepr[iTrans + 1]
+                          ] = hoppingPhase[iTrans]
+
+        xFinal[iReprUp] = cumulIndex[iReprUp] + xIndOfReprDownA
+        yFinal[iReprUp] = cumulIndex[iReprUp] + yIndOfReprDownA
+        phasesFinal[iReprUp] = hoppingPhaseA
+
+        sums = sums + np.size(xIndOfReprDownA)
+        cumulIndFinal[iReprUp + 1] = sums
+
+    xFinalA = np.zeros(cumulIndFinal[-1], dtype=int)
+    yFinalA = np.zeros(cumulIndFinal[-1], dtype=int)
+    phasesFinalA = np.zeros(cumulIndFinal[-1], dtype=complex)
+
+    for iReprUp in range(nReprUp):
+        xFinalA[cumulIndFinal[iReprUp]:cumulIndFinal[iReprUp + 1]
+                ] = xFinal[iReprUp]
+        yFinalA[cumulIndFinal[iReprUp]:cumulIndFinal[iReprUp + 1]
+                ] = yFinal[iReprUp]
+        phasesFinalA[cumulIndFinal[iReprUp]:cumulIndFinal[iReprUp + 1]
+                     ] = phasesFinal[iReprUp]
+
+    nHubbardStates = cumulIndex[-1]
+    normHubbardStatesA = np.zeros(nHubbardStates)
+    for iReprUp in range(nReprUp):
+        normHubbardStatesA[cumulIndex[iReprUp]: cumulIndex[iReprUp + 1]
+                           ] = normHubbardStates[iReprUp]
+
+    normHubbardStates = np.multiply(np.sqrt(normHubbardStatesA[xFinalA]),
+                                    np.sqrt(normHubbardStatesA[yFinalA]))
+    H_down_elems = -paramT / nSites * np.divide(phasesFinalA,
+                                                normHubbardStates)
+
+    FinL = np.size(xFinalA)
+    for ii in range(FinL):
+        for jj in range(ii + 1, FinL, 1):
+            if xFinalA[ii] == xFinalA[jj] and yFinalA[ii] == yFinalA[jj]:
+                H_down_elems[ii] = H_down_elems[ii] + H_down_elems[jj]
+
+                H_down_elems[jj] = 0
+                xFinalA[jj] = nHubbardStates - 1
+                yFinalA[jj] = nHubbardStates - 1
+
+    H_down = sparse.csr_matrix((H_down_elems, (xFinalA, yFinalA)),
+                               shape=(nHubbardStates, nHubbardStates))
+    return (H_down + H_down.transpose().conjugate())/2
+
+
+def calcHamiltonUpOnlyTrans(
+        basisReprUp, compDownStatesPerRepr, paramT, indNeighbors,
+        normHubbardStates, symOpInvariantsUp, kValue, index2ReprUp,
+        symOp2ReprUp, intStatesUp, latticeSize, PP):
+    """
+    For the Hilbert space with the basis with a specific k-symmetry,
+    computes the Hamiltonian elements holding the terms due to nearest neighbor
+    hopping between up-spin part of the basis.
+
+    Parameters
+    ==========
+    basisReprUp : list of 2d array of int
+        array of basisstates for each representation
+    compDownStatesPerRepr : list of 2d array of int
+        array of basisstates for each representation
+    paramT : float
+        The nearest neighbor hopping integral
+    indNeighbors : list of list of str
+        a list of indices that are the nearest neighbors of the indexed
+        lattice site
+    normHubbardStates : dict of 1d array of floats
+        Normalized basis vectors for the Hubbard model
+    symOpInvariants : 2d array of int
+        Each row signifies symmtery operations that leave the corresponding
+        basis vector invariant
+    kValue : float
+        The length of the reciprocal lattice vector
+    index2ReprUp : 1d array of int
+        array of ints that represent the up-spin basis members
+    symOp2ReprUp : 2d array of ints
+        each row indicates symmetry operations that leave the basis member
+        invariant.
+    intStatesUp : np.array of int
+        each int represents the up-spin basis member
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+
+    Returns
+    -------
+    H_up : csr_matrix
+        The matrix elements that are associated with hopping between spin-down
+        parts of the chosen basis.
+    """
+    [nReprUp, nSites] = np.shape(basisReprUp)
+    nSites = latticeSize[0]
+    bin2dez = np.arange(nSites-1, -1, -1)
+    bin2dez = np.power(2, bin2dez)
+
+    # determine if more than trivial T^0 translation is possible
+    nTranslations = np.zeros(nReprUp, dtype=int)
+    cumulIndex = np.zeros(nReprUp+1, dtype=int)
+    cumulIndex[0] = 0
+    sumL = 0
+    for iReprUp in range(nReprUp):
+        rt = symOpInvariantsUp[iReprUp, :]
+        nTranslations[iReprUp] = np.count_nonzero(
+            np.logical_and(rt != 0, rt != 2))
+
+        sumL = sumL + np.size(normHubbardStates[iReprUp])
+        cumulIndex[iReprUp+1] = sumL
+
+    # Translational phases to UP spin representatives
+    transPhases2ReprUp = np.sign(index2ReprUp)
+    # pull out phases of repr. linking list:
+    index2ReprUp = np.abs(index2ReprUp)
+
+    B2 = basisReprUp[:, indNeighbors]
+    B2 = np.logical_xor(basisReprUp, B2)
+
+    TwoA = np.argwhere(B2)
+    xIndOfReprUp = TwoA[:, 0]
+    d = TwoA[:, 1]
+
+    f = indNeighbors[d]
+    f1 = np.append(d, f, axis=0)
+    d1 = np.append(np.arange(np.count_nonzero(B2)), np.arange(np.count_nonzero(
+        B2)), axis=0)
+    F_i = basisReprUp[np.sum(B2, axis=1) == 0, :]
+    F = np.sum(F_i * bin2dez, axis=1)
+    B2 = basisReprUp[xIndOfReprUp, :]
+    d1 = sparse.csr_matrix((np.ones(np.size(d1)), (d1, f1)),
+                           shape=(np.max(d1) + 1, nSites))
+    hoppingPhase = HubbardPhase(B2, d1, d, f, PP)
+    d = np.logical_xor(d1.todense(), B2)
+    prodd = d * np.reshape(bin2dez, (nSites, 1))
+    d = np.sum(prodd, axis=1)
+
+    d = np.squeeze(np.asarray(d))
+    f = np.append(d, F, axis=0)
+
+    F = np.setdiff1d(intStatesUp, f)
+    f = np.append(f, F)
+    [uniqueInteger, indUniqueInteger, B2] = np.unique(f, return_index=True,
+                                                      return_inverse=True)
+
+    yIndOfCycleUp = B2[np.arange(0, np.size(xIndOfReprUp), 1)]
+    yIndOfReprUp = index2ReprUp[yIndOfCycleUp] - 1
+    yIndOfReprUp = yIndOfReprUp.astype('int')
+    symOp2ReprUp = symOp2ReprUp[yIndOfCycleUp]
+    combPhases = np.multiply(transPhases2ReprUp[yIndOfCycleUp], hoppingPhase)
+    xIndHubbUp = cumulIndex[xIndOfReprUp]
+    yIndHubbUp = cumulIndex[yIndOfReprUp]
+    nConnectedUpStates = np.size(xIndOfReprUp)
+    xFinal = {}
+    yFinal = {}
+    phasesFinal = {}
+    cumFinal = np.zeros(nConnectedUpStates+1)
+    sumF = 0
+    cumFinal[0] = sumF
+
+    for iStates in range(nConnectedUpStates):
+        stateIndex = yIndOfReprUp[iStates]
+        downSpinState1 = compDownStatesPerRepr[xIndOfReprUp[iStates]]
+        downSpinState2 = compDownStatesPerRepr[stateIndex]
+        DLT = np.argwhere(symOpInvariantsUp[stateIndex, :])
+
+        translationPower = DLT[:, 0]
+
+        phasesFromTransInvariance = symOpInvariantsUp[stateIndex, DLT]
+        phasesFromTransInvariance = phasesFromTransInvariance[:, 0]
+
+        combTranslation = symOp2ReprUp[iStates] + translationPower
+        nTrans = np.size(combTranslation)
+
+        xInd = {}
+        yInd = {}
+        phaseFactor = {}
+
+        cumI = np.zeros(nTrans + 1, dtype=int)
+        sumE = 0
+        cumI[0] = sumE
+
+        for iTrans in range(nTrans):
+            Tss = -combTranslation[iTrans]
+            [transStates, transPhases] = cubicSymmetries(
+                downSpinState2, int(Tss), latticeSize, PP)
+
+            intTransStates = np.sum(transStates * bin2dez, axis=1)
+            intStatesOne = np.sum(downSpinState1 * bin2dez, axis=1)
+
+            [dumpV, xInd[iTrans], yInd[iTrans]] = intersect_mtlb(
+                intStatesOne, intTransStates)
+            phaseFactor[iTrans] = transPhases[yInd[iTrans]]
+
+            sumE = sumE + np.size(xInd[iTrans])
+            cumI[iTrans + 1] = sumE
+
+        xIndA = np.zeros(cumI[-1])
+        yIndA = np.zeros(cumI[-1])
+
+        for iTrans in range(nTrans):
+            xIndA[cumI[iTrans]: cumI[iTrans + 1]] = xInd[iTrans]
+            yIndA[cumI[iTrans]: cumI[iTrans + 1]] = yInd[iTrans]
+
+        xFinal[iStates] = xIndHubbUp[iStates] + xIndA
+        yFinal[iStates] = yIndHubbUp[iStates] + yIndA
+        specCombPhase = combPhases[iStates]
+        cumP = np.zeros(nTranslations[stateIndex]+1, dtype=int)
+        sump = 0
+        cumP[0] = sump
+
+        for iTrans in range(nTranslations[stateIndex]):
+            phaseFromTransUp = phasesFromTransInvariance[iTrans]
+            expPhases = np.exp(1J * kValue * combTranslation[iTrans])
+            phaseFactor[iTrans] = phaseFactor[
+                iTrans] * specCombPhase * phaseFromTransUp * expPhases
+            sump = sump + 1
+            cumP[iTrans+1] = sump
+
+        if nTrans == 1:
+            phasesFinal[iStates] = phaseFactor[0]
+
+        else:
+            phasesFinal[iStates] = phaseFactor[0]
+
+            for noss in range(1, nTrans, 1):
+                phasesFinal[iStates] = np.hstack([phasesFinal[
+                    iStates], phaseFactor[noss]])
+
+    phasesFinalA = phasesFinal[0]
+    xFinalA = xFinal[0]
+    yFinalA = yFinal[0]
+
+    if nConnectedUpStates > 1:
+        for noss in range(1, nConnectedUpStates, 1):
+            phasesFinalA = np.hstack([phasesFinalA, phasesFinal[noss]])
+            xFinalA = np.hstack([xFinalA, xFinal[noss]])
+            yFinalA = np.hstack([yFinalA, yFinal[noss]])
+
+    normHubbardStatesA = normHubbardStates[0]
+    for iReprUp in range(1, nReprUp, 1):
+        normHubbardStatesA = np.hstack([normHubbardStatesA, normHubbardStates[
+            iReprUp]])
+
+    nHubbardStates = np.size(normHubbardStatesA)
+    normHubbardStates = np.multiply(np.sqrt(normHubbardStatesA[
+        xFinalA.astype(int)]),
+        np.sqrt(normHubbardStatesA[yFinalA.astype(int)]))
+    H_up_elems = -paramT / nSites * np.divide(phasesFinalA, normHubbardStates)
+
+    FinL = np.size(xFinalA)
+    for ii in range(FinL):
+        for jj in range(ii + 1, FinL, 1):
+
+            if xFinalA[ii] == xFinalA[jj] and yFinalA[ii] == yFinalA[jj]:
+                H_up_elems[ii] = H_up_elems[ii] + H_up_elems[jj]
+                H_up_elems[jj] = 0
+                xFinalA[jj] = nHubbardStates - 1
+                yFinalA[jj] = nHubbardStates - 1
+
+    H_up = sparse.csr_matrix((H_up_elems, (xFinalA, yFinalA)), shape=(
+        nHubbardStates, nHubbardStates))
+
+    return (H_up + H_up.transpose().conjugate())/2
+
+
+def UnitaryTrans(latticeSize, basisStatesUp, basisStatesDown, PP):
+    """
+    Computes the unitary matrix that block-diagonalizes the Hamiltonian written
+    in a basis with k-vector symmetry.
+
+    Parameters
+    ==========
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    basisStatesUp : 2d array of int
+        a 2d numpy array with each basis vector of spin-up's as a row
+    basisStatesDown : np.array of int
+        a 2d numpy array with each basis vector of spin-down's as a row
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+
+    Returns
+    -------
+    Qobj(Usss) : Qobj(csr_matrix)
+        The unitary matrix that block-diagonalizes the Hamiltonian written in
+        a basis with k-vector symmetry.
+    """
+    [nBasisStatesUp, nSites] = np.shape(basisStatesUp)
+    [nBasisStatesDown, dumpV] = np.shape(basisStatesDown)
+
+    [basisReprUp, symOpInvariantsUp, index2ReprUp, symOp2ReprUp
+     ] = findReprOnlyTrans(basisStatesUp, latticeSize, PP)
+
+    bin2dez = np.arange(nSites-1, -1, -1)
+    bin2dez = np.power(2, bin2dez)
+    intDownStates = np.sum(basisStatesDown * bin2dez, axis=1)
+    intUpStates = np.sum(basisStatesUp * bin2dez, axis=1)
+    kVector = np.arange(start=0, stop=2 * np.pi,
+                        step=2 * np.pi / latticeSize[0])
+
+    Is = 0
+    RowIndexUs = 0
+    # loop over k-vector
+    for ikVector in range(latticeSize[0]):
+        kValue = kVector[ikVector]
+
+        [compDownStatesPerRepr, compInd2ReprDown, normHubbardStates
+         ] = combine2HubbardBasisOnlyTrans(
+         symOpInvariantsUp, basisStatesDown, latticeSize, kValue, PP, Nmax=1)
+        [nReprUp, nSites] = np.shape(basisReprUp)
+        cumulIndex = np.zeros(nReprUp+1, dtype=int)
+        cumulIndex[0] = 0
+        sumL = 0
+        for iReprUp in range(nReprUp):
+            rt = symOpInvariantsUp[iReprUp, :]
+            rt = rt[rt == 1]
+            sumL = sumL + np.size(normHubbardStates[iReprUp])
+            cumulIndex[iReprUp+1] = sumL
+        for k in range(nReprUp):
+            UpState = basisReprUp[k, :]
+            basisStatesDown_k = compDownStatesPerRepr[k]
+            fillingUp = np.count_nonzero(UpState)
+
+            for l in range(cumulIndex[k], cumulIndex[k + 1], 1):
+                DownState = basisStatesDown_k[l - cumulIndex[k], :]
+                fillingDown = np.count_nonzero(DownState)
+
+                # calculate period
+                for h in range(1, nSites + 1, 1):
+                    DownState_S = np.roll(DownState, -h)
+                    UpState_S = np.roll(UpState, -h)
+
+                    if ((DownState_S == DownState).all() and (
+                            UpState_S == UpState).all()):
+                        pn = h
+                        break
+                no_of_flips = 0
+                DownState_shifted = DownState
+                UpState_shifted = UpState
+
+                for m in range(nSites):
+                    DownState_m = np.roll(DownState, -m)
+                    DownState_m_int = np.sum(DownState_m * bin2dez, axis=0)
+
+                    UpState_m = np.roll(UpState, -m)
+                    UpState_m_int = np.sum(UpState_m * bin2dez, axis=0)
+
+                    DLT = np.argwhere(intDownStates == DownState_m_int)
+                    ind_down = DLT[:, 0][0]
+                    DLT = np.argwhere(intUpStates == UpState_m_int)
+                    ind_up = DLT[:, 0][0]
+
+                    if m > 0:
+                        DownState_shifted = np.roll(DownState_shifted, -1)
+                        UpState_shifted = np.roll(UpState_shifted, -1)
+
+                        if np.mod(fillingUp + 1, 2):
+                            no_of_flips = no_of_flips + UpState_shifted[-1]
+
+                        if np.mod(fillingDown + 1, 2):
+                            no_of_flips = no_of_flips + DownState_shifted[-1]
+
+                    else:
+                        no_of_flips = 0
+
+                    NewRI = l + RowIndexUs
+                    NewCI = ind_up * nBasisStatesDown + ind_down
+
+                    NewEn = np.sqrt(pn) / nSites * np.power(
+                        PP, no_of_flips) * np.exp(
+                            -2 * np.pi * 1J / nSites * ikVector * m)
+
+                    if Is == 0:
+                        UssRowIs = np.array([NewRI])
+                        UssColIs = np.array([NewCI])
+                        UssEntries = np.array([NewEn])
+                        Is = 1
+                    elif Is > 0:
+                        DLT = np.argwhere(UssRowIs == NewRI)
+                        iArg1 = DLT[:, 0]
+                        DLT = np.argwhere(UssColIs == NewCI)
+                        iArg2 = DLT[:, 0]
+                        if np.size(np.intersect1d(iArg1, iArg2)):
+                            AtR = np.intersect1d(iArg1, iArg2)
+                            UssEntries[AtR] = UssEntries[AtR] + NewEn
+                        else:
+                            Is = Is + 1
+                            UssRowIs = np.append(UssRowIs, np.array([NewRI]),
+                                                 axis=0)
+                            UssColIs = np.append(UssColIs, np.array([NewCI]),
+                                                 axis=0)
+                            UssEntries = np.append(UssEntries, np.array(
+                                [NewEn]), axis=0)
+        RowIndexUs = RowIndexUs + cumulIndex[-1]
+    Usss = sparse.csr_matrix((UssEntries, (UssRowIs, UssColIs)), shape=(
+        nBasisStatesUp * nBasisStatesDown, nBasisStatesUp * nBasisStatesDown))
+    return Qobj(Usss)
+
+
+def UnitaryTrans_k(latticeSize, basisStatesUp, basisStatesDown, kval, PP):
+    """
+    Computes the section of the unitary matrix that computes the
+    block-diagonalized Hamiltonian written in a basis with the given k-vector
+    symmetry.
+
+    Parameters
+    ==========
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    basisStatesUp : 2d array of int
+        a 2d numpy array with each basis vector of spin-up's as a row
+    basisStatesDown : np.array of int
+        a 2d numpy array with each basis vector of spin-down's as a row
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+
+    Returns
+    -------
+    Qobj(Usss) : Qobj(csr_matrix)
+        The section of the unitary matrix that gives the Hamiltonian written in
+        a basis with k-vector symmetry.
+    """
+    [nBasisStatesUp, nSites] = np.shape(basisStatesUp)
+    [nBasisStatesDown, dumpV] = np.shape(basisStatesDown)
+
+    [basisReprUp, symOpInvariantsUp, index2ReprUp, symOp2ReprUp
+     ] = findReprOnlyTrans(basisStatesUp, latticeSize, PP)
+
+    bin2dez = np.arange(nSites-1, -1, -1)
+    bin2dez = np.power(2, bin2dez)
+    intDownStates = np.sum(basisStatesDown * bin2dez, axis=1)
+    intUpStates = np.sum(basisStatesUp*bin2dez, axis=1)
+    kVector = np.arange(start=0, stop=2 * np.pi,
+                        step=2 * np.pi / latticeSize[0])
+
+    Is = 0
+    RowIndexUs = 0
+    for ikVector in np.arange(kval, kval + 1, 1):
+        kValue = kVector[ikVector]
+
+        [compDownStatesPerRepr, compInd2ReprDown, normHubbardStates
+         ] = combine2HubbardBasisOnlyTrans(
+         symOpInvariantsUp, basisStatesDown, latticeSize, kValue, PP, Nmax=1)
+        [nReprUp, nSites] = np.shape(basisReprUp)
+        cumulIndex = np.zeros(nReprUp+1, dtype=int)
+        cumulIndex[0] = 0
+        sumL = 0
+        for iReprUp in range(nReprUp):
+            rt = symOpInvariantsUp[iReprUp, :]
+            rt = rt[rt == 1]
+            sumL = sumL + np.size(normHubbardStates[iReprUp])
+            cumulIndex[iReprUp+1] = sumL
+
+        for k in range(nReprUp):
+            UpState = basisReprUp[k, :]
+            basisStatesDown_k = compDownStatesPerRepr[k]
+
+            fillingUp = np.count_nonzero(UpState)
+
+            for l in range(cumulIndex[k], cumulIndex[k + 1], 1):
+                DownState = basisStatesDown_k[l-cumulIndex[k], :]
+                fillingDown = np.count_nonzero(DownState)
+
+                # calculate period
+                for h in range(1, nSites+1, 1):
+                    DownState_S = np.roll(DownState, -h)
+                    UpState_S = np.roll(UpState, -h)
+
+                    if ((DownState_S == DownState).all() and (
+                            UpState_S == UpState).all()):
+                        pn = h
+                        break
+                no_of_flips = 0
+                DownState_shifted = DownState
+                UpState_shifted = UpState
+
+                for m in range(nSites):
+                    DownState_m = np.roll(DownState, -m)
+                    DownState_m_int = np.sum(DownState_m * bin2dez, axis=0)
+
+                    UpState_m = np.roll(UpState, -m)
+                    UpState_m_int = np.sum(UpState_m * bin2dez, axis=0)
+
+                    DLT = np.argwhere(intDownStates == DownState_m_int)
+                    ind_down = DLT[:, 0][0]
+                    DLT = np.argwhere(intUpStates == UpState_m_int)
+                    ind_up = DLT[:, 0][0]
+
+                    if m > 0:
+                        DownState_shifted = np.roll(DownState_shifted, -1)
+                        UpState_shifted = np.roll(UpState_shifted, -1)
+
+                        if np.mod(fillingUp + 1, 2):
+                            no_of_flips = no_of_flips + UpState_shifted[-1]
+
+                        if np.mod(fillingDown + 1, 2):
+                            no_of_flips = no_of_flips + DownState_shifted[-1]
+                    else:
+                        no_of_flips = 0
+
+                    NewRI = l + 0 * RowIndexUs
+                    NewCI = ind_up * nBasisStatesDown + ind_down
+                    NewEn = np.sqrt(pn) / nSites * np.power(
+                        PP, no_of_flips) * np.exp(
+                            -2 * np.pi * 1J / nSites * ikVector * m)
+
+                    if Is == 0:
+                        UssRowIs = np.array([NewRI])
+                        UssColIs = np.array([NewCI])
+                        UssEntries = np.array([NewEn])
+                        Is = 1
+                    elif Is > 0:
+                        DLT = np.argwhere(UssRowIs == NewRI)
+                        iArg1 = DLT[:, 0]
+                        DLT = np.argwhere(UssColIs == NewCI)
+                        iArg2 = DLT[:, 0]
+                        if np.size(np.intersect1d(iArg1, iArg2)):
+                            AtR = np.intersect1d(iArg1, iArg2)
+                            UssEntries[AtR] = UssEntries[AtR] + NewEn
+                        else:
+                            Is = Is + 1
+                            UssRowIs = np.append(UssRowIs, np.array([NewRI]),
+                                                 axis=0)
+                            UssColIs = np.append(UssColIs, np.array([NewCI]),
+                                                 axis=0)
+                            UssEntries = np.append(UssEntries, np.array(
+                                [NewEn]), axis=0)
+        RowIndexUs = RowIndexUs + cumulIndex[-1]
+
+    Usss = sparse.csr_matrix((UssEntries, (UssRowIs, UssColIs)), shape=(
+        cumulIndex[-1], nBasisStatesUp * nBasisStatesDown))
+    return Qobj(Usss)
+
+
+def TransOperator(basisStatesUp, basisStatesDown, latticeSize, transL, PP):
+    """
+    Computes the translational operator that shifts kets to the right by transL
+    sites.
+
+    Parameters
+    ==========
+    basisStatesUp : 2d array of int
+        a 2d numpy array with each basis vector of spin-up's as a row
+    basisStatesDown : np.array of int
+        a 2d numpy array with each basis vector of spin-down's as a row
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    transL : int
+        the number of units/sites the translation isto be done.
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+
+    Returns
+    -------
+    TransOp : Qobj
+        the translational operator that shifts kets to the right by transL
+        sites.
+    """
+    [nBasisStatesUp, nSites] = np.shape(basisStatesUp)
+    [nBasisStatesDown, dumpV] = np.shape(basisStatesDown)
+    nHubbardStates = nBasisStatesDown * nBasisStatesUp
+
+    Is = 0
+
+    for ux in range(nBasisStatesUp):
+        UpState = basisStatesUp[ux, :]
+        for dx in range(nBasisStatesDown):
+            DownState = basisStatesDown[dx, :]
+            ix = ux * nBasisStatesDown + dx
+
+            DownState_T = np.roll(DownState, -transL)
+            UpState_T = np.roll(UpState, -transL)
+
+            DS_cross_edge = np.sum(DownState[np.arange(transL)], axis=0)
+            US_cross_edge = np.sum(UpState[np.arange(transL)], axis=0)
+
+            if np.mod(np.sum(DownState), 2):
+                phase_FD = 1
+            else:
+                phase_FD = np.power(PP, DS_cross_edge)
+
+            if np.mod(np.sum(UpState), 2):
+                phase_FU = 1
+            else:
+                phase_FU = np.power(PP, US_cross_edge)
+
+            for ux1 in range(nBasisStatesUp):
+                UpState_S = basisStatesUp[ux1, :]
+                for dx1 in range(nBasisStatesDown):
+                    DownState_S = basisStatesDown[dx1, :]
+                    ix1 = ux1 * nBasisStatesDown + dx1
+
+                    if ((DownState_S == DownState_T).all() and (
+                            UpState_S == UpState_T).all()):
+
+                        if Is == 0:
+                            UssRowIs = np.array([ix])
+                            UssColIs = np.array([ix1])
+                            UssEntries = np.array([phase_FD * phase_FU])
+                            Is = 1
+                        else:
+                            Is = Is + 1
+                            UssRowIs = np.append(UssRowIs, np.array([ix]),
+                                                 axis=0)
+                            UssColIs = np.append(UssColIs, np.array([ix1]),
+                                                 axis=0)
+                            UssEntries = np.append(UssEntries, np.array(
+                                [phase_FD * phase_FU]), axis=0)
+
+    TransOp = sparse.csr_matrix((UssEntries, (UssRowIs, UssColIs)), shape=(
+        nHubbardStates, nHubbardStates))
+    return TransOp
+
+
+def calcHamiltonDownOnlyTransBoson(
+        compDownStatesPerRepr, compInd2ReprDown, paramT, paramU, indNeighbors,
+        normHubbardStates, symOpInvariantsUp, kValue, basisStatesDown,
+        latticeSize, PP, Nmax, Trans):
+    """
+    For the bosonic Hilbert space with the basis with/without a specific
+    k-symmetry, computes the Hamiltonian elements holding the terms due to
+    nearest neighbor hopping.
+
+    Parameters
+    ==========
+    compDownStatesPerRepr : list of 2d array of int
+        array of basisstates for each representation
+    compInd2ReprDown : np.array of int
+        each row represents a basis in representation
+    paramT : float
+        The nearest neighbor hopping integral
+    paramU : float
+        The bosonic Hubbard interaction strength
+    indNeighbors : list of list of str
+        a list of indices that are the nearest neighbors of the indexed
+        lattice site
+    normHubbardStates : dict of 1d array of floats
+        Normalized basis vectors for the Hubbard model
+    symOpInvariants : 2d array of int
+        Each row signifies symmtery operations that leave the corresponding
+        basis vector invariant
+    kValue : float
+        The length of the reciprocal lattice vector
+    basisStatesDown : np.array of int
+        a 2d numpy array with each basis vector as a row
+    latticeSize : list of int
+        it has a single element as the number of cells as an integer.
+    PP : int
+        The exchange phase factor for particles, +1 for bosons, -1 for fermions
+    Nmax : int
+        The bosonic maximum occupation number for a site.
+    Trans : int
+        indicates if a k-vector symmetric basis is being used (1) or not (0)
+
+    Returns
+    -------
+    H_down : csr_matrix
+        The matrix elements that are associated with hopping between bosons on
+        nearest neighbor sites.
+
+    """
+    [nReprUp, nSites] = np.shape(symOpInvariantsUp)
+
+    bin2dez = np.arange(nSites-1, -1, -1)
+    bin2dez = np.power(Nmax+1, bin2dez)
+
+    RindNeighbors = np.zeros((nSites,), dtype=int)
+    for i in range(nSites):
+        j = indNeighbors[i]
+        RindNeighbors[j] = i
+
+    cumulIndex = np.zeros(nReprUp+1, dtype=int)
+    cumulIndex[0] = 0
+    sumL = 0
+    nZs = 0
+    for iReprUp in range(nReprUp):
+        nZs = nZs + np.count_nonzero(compDownStatesPerRepr[iReprUp])
+        sumL = sumL + np.shape(compDownStatesPerRepr[iReprUp])[0]
+        cumulIndex[iReprUp+1] = sumL
+
+    MaxE = np.sum(Nmax*np.ones(nSites) * bin2dez, axis=0)
+
+    dg_x = -1
+    xxd = np.zeros(cumulIndex[-1], dtype=int)
+    H_down_U_elems = np.zeros(cumulIndex[-1], dtype=complex)
+
+    xFinalA = -np.ones(2*nZs, dtype=int)
+    yFinalA = -np.ones(2*nZs, dtype=int)
+    H_down_elems = np.zeros(2*nZs, dtype=complex)
+
+    enI = -1
+    for iReprUp in range(nReprUp):
+        basisStates = compDownStatesPerRepr[iReprUp]
+        nBasisStates = np.shape(basisStates)[0]
+
+        periods_bs = []
+        for k in range(nBasisStates):
+            DownState = basisStates[k, :]
+
+            # calculate period
+            for h in range(1, nSites+1, 1):
+                DownState_S = np.roll(DownState, -h)
+
+                if (DownState_S == DownState).all():
+                    pn = h
+                    periods_bs.append(pn)
+                    break
+
+        indBasis = np.sum(basisStates * bin2dez, axis=1)
+        for iBasis in range(nBasisStates):
+            ThisBasis = basisStates[iBasis, :]
+
+            indBases = np.zeros((nBasisStates, nSites), dtype=int)
+            for r in range(nSites):
+                rindBasis = np.sum(np.roll(basisStates, r, axis=1
+                                           ) * bin2dez, axis=1)
+                indBases[:, r] = rindBasis
+
+            dg_x = dg_x + 1
+            xxd[dg_x] = dg_x
+            H_down_U_elems[dg_x] = paramU * np.sum(np.multiply(
+                ThisBasis, ThisBasis)-ThisBasis, axis=0)
+
+            for iSite in range(nSites):
+                hopFrom = ThisBasis[iSite]
+                if hopFrom > 0:
+                    hoppedTo1 = int(indNeighbors[iSite])
+                    hoppedTo2 = int(RindNeighbors[iSite])
+
+                    y1 = np.sum(ThisBasis * bin2dez, axis=0) + np.power(
+                        Nmax+1, nSites-1-hoppedTo1) - np.power(
+                            Nmax+1, nSites-1-iSite)
+                    y2 = np.sum(ThisBasis * bin2dez, axis=0) + np.power(
+                        Nmax+1, nSites-1-hoppedTo2) - np.power(
+                            Nmax+1, nSites-1-iSite)
+
+                    if ThisBasis[hoppedTo1]+1 > Nmax or (int(
+                            y1) not in indBases):
+                        count1 = False
+                    else:
+                        count1 = True
+
+                    if ThisBasis[hoppedTo2]+1 > Nmax or (int(
+                            y2) not in indBases):
+                        count2 = False
+                    else:
+                        count2 = True
+
+                    if count1:
+                        if Trans:
+                            hopd1 = np.argwhere(int(y1) == indBases)[0][0]
+                            ph_i = np.argwhere(int(y1) == indBases)[:, 1]
+                        else:
+                            hopd1 = np.argwhere(int(y1) == indBasis)[0][0]
+
+                        DLT = np.argwhere(xFinalA == iBasis)
+                        iArg1 = DLT[:, 0]
+                        DLT = np.argwhere(yFinalA == hopd1)
+                        iArg2 = DLT[:, 0]
+                        if np.size(np.intersect1d(iArg1, iArg2)):
+                            AtR = np.intersect1d(iArg1, iArg2)
+                            if Trans:
+                                sumT = 0
+                                for m in range(len(ph_i)):
+                                    sumT = sumT + np.exp(-1J*kValue*ph_i[m])
+                                H_down_elems[AtR] = H_down_elems[
+                                    AtR] - paramT * np.sqrt(periods_bs[
+                                        iBasis] * periods_bs[hopd1] * (
+                                            basisStates[iBasis, iSite]) * (
+                                                basisStates[
+                                                    iBasis, hoppedTo1
+                                                    ]+1)) / nSites * sumT
+                            else:
+                                H_down_elems[AtR] = H_down_elems[
+                                    AtR] - paramT * np.sqrt((basisStates[
+                                        iBasis, iSite])*(basisStates[
+                                            iBasis, hoppedTo1]+1))
+                        else:
+                            enI = enI + 1
+                            xFinalA[enI] = iBasis
+                            yFinalA[enI] = hopd1
+                            if Trans:
+                                sumT = 0
+                                for m in range(len(ph_i)):
+                                    sumT = sumT + np.exp(-1J*kValue*ph_i[m])
+                                H_down_elems[enI] = -paramT * np.sqrt(
+                                    periods_bs[iBasis] * periods_bs[hopd1] * (
+                                        basisStates[iBasis, iSite]) * (
+                                            basisStates[iBasis, hoppedTo1]+1)
+                                            ) / nSites * sumT
+                            else:
+                                H_down_elems[enI] = -paramT * np.sqrt((
+                                    basisStates[iBasis, iSite])*(basisStates[
+                                        iBasis, hoppedTo1]+1))
+
+                    if count2:
+                        if Trans:
+                            hopd2 = np.argwhere(int(y2) == indBases)[0][0]
+                            ph_i = np.argwhere(int(y2) == indBases)[:, 1]
+                        else:
+                            hopd2 = np.argwhere(int(y2) == indBasis)[0][0]
+
+                        DLT = np.argwhere(xFinalA == iBasis)
+                        iArg1 = DLT[:, 0]
+                        DLT = np.argwhere(yFinalA == hopd2)
+                        iArg2 = DLT[:, 0]
+                        if np.size(np.intersect1d(iArg1, iArg2)):
+                            AtR = np.intersect1d(iArg1, iArg2)
+                            if Trans:
+                                sumT = 0
+                                for m in range(len(ph_i)):
+                                    sumT = sumT + np.exp(
+                                        -1J * kValue * ph_i[m])
+
+                                H_down_elems[AtR] = H_down_elems[
+                                    AtR] - paramT * np.sqrt(periods_bs[
+                                        iBasis] * periods_bs[hopd2] * (
+                                            basisStates[iBasis, iSite]) * (
+                                                basisStates[
+                                                    iBasis, hoppedTo2]+1)
+                                                ) / nSites * sumT
+                            else:
+                                H_down_elems[AtR] = H_down_elems[
+                                    AtR] - paramT * np.sqrt((basisStates[
+                                        iBasis, iSite])*(basisStates[
+                                            iBasis, hoppedTo2]+1))
+                        else:
+                            enI = enI + 1
+                            xFinalA[enI] = iBasis
+                            yFinalA[enI] = hopd2
+                            if Trans:
+                                sumT = 0
+                                for m in range(len(ph_i)):
+                                    sumT = sumT + np.exp(-1J*kValue*ph_i[m])
+
+                                H_down_elems[enI] = -paramT * np.sqrt(
+                                    periods_bs[iBasis] * periods_bs[hopd2] * (
+                                        basisStates[iBasis, iSite]) * (
+                                            basisStates[iBasis, hoppedTo2]+1)
+                                            ) / nSites * sumT
+
+                            else:
+                                H_down_elems[enI] = -paramT * np.sqrt((
+                                    basisStates[iBasis, iSite])*(basisStates[
+                                        iBasis, hoppedTo2]+1))
+
+    xFinalA = np.delete(xFinalA, np.arange(enI+1, 2*nZs, 1))
+    yFinalA = np.delete(yFinalA, np.arange(enI+1, 2*nZs, 1))
+    H_down_elems = np.delete(H_down_elems, np.arange(enI+1, 2*nZs, 1))
+
+    H_down = sparse.csr_matrix((H_down_elems, (xFinalA, yFinalA)), shape=(
+        cumulIndex[-1], cumulIndex[-1]))
+    H_down = H_down + sparse.csr_matrix((H_down_U_elems, (xxd, xxd)),
+                                        shape=(cumulIndex[-1], cumulIndex[-1]))
+
+    return (H_down + H_down.transpose().conjugate())/2

--- a/qutip_lattice/version.py
+++ b/qutip_lattice/version.py
@@ -1,4 +1,4 @@
 # THIS FILE IS GENERATED FROM QUTIP SETUP.PY
 short_version = '0.1.0'
-version = '0.1.0.dev0+3f6ba70'
+version = '0.1.0.dev0+d48bd6e'
 release = False


### PR DESCRIPTION
@Ericgig  I addressed the issues raised last time.
1) Split the lattice.py into multiple files.
2) removed duplicate stuff you pointed out.

It works with both qutip 4 and 5, since it is very independent actually.

I am working on a write-up to explain more. 
Lattice1d is for single particle physics only.
The other classes like Lattice1d_fermi_hubbard or Lattice_1d_bose_hubbard are for multi particle physics. The user will only use one of them in their work, like there would not be any mix and match. The only commonality is they are both lattices. But all models are very disparate and user would only import one and work exclusively in one. More details to follow in the write-up.

Example usage can be found at https://github.com/sbisw002/qutip-lattice-notebooks/tree/master

I hope qutip-5 is on track!

